### PR TITLE
Fix intel/geoip not processing upgrades

### DIFF
--- a/intel/geoip/database.go
+++ b/intel/geoip/database.go
@@ -59,20 +59,20 @@ func doReload() error {
 
 func openDBs() error {
 	var err error
-	file, err := updates.GetFile("intel/geoip/geoip-city.mmdb")
+	dbCityFile, err = updates.GetFile("intel/geoip/geoip-city.mmdb")
 	if err != nil {
 		return fmt.Errorf("could not get GeoIP City database file: %s", err)
 	}
-	dbCity, err = maxminddb.Open(file.Path())
+	dbCity, err = maxminddb.Open(dbCityFile.Path())
 	if err != nil {
 		return err
 	}
 
-	file, err = updates.GetFile("intel/geoip/geoip-asn.mmdb")
+	dbASNFile, err = updates.GetFile("intel/geoip/geoip-asn.mmdb")
 	if err != nil {
 		return fmt.Errorf("could not get GeoIP ASN database file: %s", err)
 	}
-	dbASN, err = maxminddb.Open(file.Path())
+	dbASN, err = maxminddb.Open(dbASNFile.Path())
 	if err != nil {
 		return err
 	}

--- a/intel/geoip/module.go
+++ b/intel/geoip/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/safing/portbase/modules"
+	"github.com/safing/portmaster/updates"
 )
 
 var (
@@ -16,9 +17,9 @@ func init() {
 
 func prep() error {
 	return module.RegisterEventHook(
-		"updates",
-		"resource update",
-		"upgrade databases",
+		updates.ModuleName,
+		updates.ResourceUpdateEvent,
+		"Check for GeoIP database updates",
 		upgradeDatabases,
 	)
 }

--- a/netenv/main.go
+++ b/netenv/main.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	networkChangedEvent      = "network changed"
-	onlineStatusChangedEvent = "online status changed"
+	NetworkChangedEvent      = "network changed"
+	OnlineStatusChangedEvent = "online status changed"
 )
 
 var (
@@ -15,8 +15,8 @@ var (
 
 func init() {
 	module = modules.Register("netenv", nil, start, nil)
-	module.RegisterEvent(networkChangedEvent)
-	module.RegisterEvent(onlineStatusChangedEvent)
+	module.RegisterEvent(NetworkChangedEvent)
+	module.RegisterEvent(OnlineStatusChangedEvent)
 }
 
 func start() error {

--- a/netenv/online-status.go
+++ b/netenv/online-status.go
@@ -156,7 +156,7 @@ func updateOnlineStatus(status OnlineStatus, portalURL, comment string) {
 
 	// trigger event
 	if changed {
-		module.TriggerEvent(onlineStatusChangedEvent, nil)
+		module.TriggerEvent(OnlineStatusChangedEvent, nil)
 		if status == StatusPortal {
 			log.Infof(`network: setting online status to %s at "%s" (%s)`, status, captivePortalURL, comment)
 		} else {
@@ -201,21 +201,17 @@ func triggerOnlineStatusInvestigation() {
 
 func monitorOnlineStatus(ctx context.Context) error {
 	for {
+		timeout := time.Minute
+		if GetOnlineStatus() != StatusOnline {
+			timeout = time.Second
+		}
 		// wait for trigger
-		if GetOnlineStatus() == StatusOnline {
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-onlineStatusInvestigationTrigger:
-			case <-time.After(1 * time.Minute):
-			}
-		} else {
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-onlineStatusInvestigationTrigger:
-			case <-time.After(1 * time.Second):
-			}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-onlineStatusInvestigationTrigger:
+
+		case <-time.After(timeout):
 		}
 
 		// enable waiting

--- a/updates/config.go
+++ b/updates/config.go
@@ -56,7 +56,7 @@ func updateRegistryConfig(_ context.Context, _ interface{}) error {
 
 	if changed {
 		registry.SelectVersions()
-		module.TriggerEvent(eventVersionUpdate, nil)
+		module.TriggerEvent(VersionUpdateEvent, nil)
 	}
 
 	return nil

--- a/updates/export.go
+++ b/updates/export.go
@@ -50,8 +50,8 @@ func initVersionExport() (err error) {
 	}
 
 	return module.RegisterEventHook(
-		"updates",
-		eventVersionUpdate,
+		ModuleName,
+		VersionUpdateEvent,
 		"export version status",
 		export,
 	)

--- a/updates/get.go
+++ b/updates/get.go
@@ -20,7 +20,7 @@ func GetPlatformFile(identifier string) (*updater.File, error) {
 		return nil, err
 	}
 
-	module.TriggerEvent(eventVersionUpdate, nil)
+	module.TriggerEvent(VersionUpdateEvent, nil)
 	return file, nil
 }
 
@@ -33,6 +33,6 @@ func GetFile(identifier string) (*updater.File, error) {
 		return nil, err
 	}
 
-	module.TriggerEvent(eventVersionUpdate, nil)
+	module.TriggerEvent(VersionUpdateEvent, nil)
 	return file, nil
 }

--- a/updates/upgrader.go
+++ b/updates/upgrader.go
@@ -37,8 +37,8 @@ var (
 
 func initUpgrader() error {
 	return module.RegisterEventHook(
-		"updates",
-		eventResourceUpdate,
+		ModuleName,
+		ResourceUpdateEvent,
 		"run upgrades",
 		upgrader,
 	)


### PR DESCRIPTION
This PR fixes a bug that causes the `intel/geoip` module to not process GeoIP upgrades correclty. It also exports constants for the events emitted by the `updates` module and contains a minor change to clarify things in `netenv`.