### PR TITLE
Add support for start and stop hooks during test setup

### DIFF
--- a/core/pmtesting/testing.go
+++ b/core/pmtesting/testing.go
@@ -81,14 +81,19 @@ func TestMainWithHooks(m *testing.M, module *modules.Module, afterStartFn, befor
 		fmt.Fprintf(os.Stderr, "failed to setup test: %s\n", err)
 		exitCode = 1
 	} else {
+		runTests := true
 		if afterStartFn != nil {
 			if err := afterStartFn(); err != nil {
 				fmt.Fprintf(os.Stderr, "failed to run test start hook: %s\n", err)
+				runTests = false
 				exitCode = 1
 			}
 		}
-		// run tests
-		exitCode = m.Run()
+
+		if runTests {
+			// run tests
+			exitCode = m.Run()
+		}
 	}
 
 	if beforeStopFn != nil {

--- a/core/pmtesting/testing.go
+++ b/core/pmtesting/testing.go
@@ -41,8 +41,17 @@ func init() {
 	flag.BoolVar(&printStackOnExit, "print-stack-on-exit", false, "prints the stack before of shutting down")
 }
 
+type TestHookFunc func() error
+
 // TestMain provides a simple unit test setup routine.
 func TestMain(m *testing.M, module *modules.Module) {
+	TestMainWithHooks(m, module, nil, nil)
+}
+
+// TestMainWithHooks provides a simple unit test setup routine and calls
+// afterStartFn after modules have started and beforeStopFn before modules
+// are shutdown.
+func TestMainWithHooks(m *testing.M, module *modules.Module, afterStartFn, beforeStopFn TestHookFunc) {
 	// enable module for testing
 	module.Enable()
 
@@ -72,8 +81,20 @@ func TestMain(m *testing.M, module *modules.Module) {
 		fmt.Fprintf(os.Stderr, "failed to setup test: %s\n", err)
 		exitCode = 1
 	} else {
+		if afterStartFn != nil {
+			if err := afterStartFn(); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to run test start hook: %s\n", err)
+				exitCode = 1
+			}
+		}
 		// run tests
 		exitCode = m.Run()
+	}
+
+	if beforeStopFn != nil {
+		if err := beforeStopFn(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to run test shutdown hook: %s\n", err)
+		}
 	}
 
 	// shutdown


### PR DESCRIPTION
This PR adds support for start and stop module hooks in `pmtesting`. It allows other modules to perform some test-setup and teardown tasks before the actual tests are executed. 
It basically adds a new `TestMainWithHooks`. This change is backwards compatible.  