### PR TITLE
Fix HTTPS online check always failing

### DIFF
--- a/netenv/online-status.go
+++ b/netenv/online-status.go
@@ -326,6 +326,8 @@ func checkOnlineStatus(ctx context.Context) {
 		// this might be a weird captive portal, just direct the user there
 		updateOnlineStatus(StatusPortal, "detectportal.firefox.com", "http request succeeded, response content not as expected")
 	}
+	// close the body now as we plan to re-uise the http.Client
+	response.Body.Close()
 
 	// 3) try a https request
 
@@ -339,7 +341,7 @@ func checkOnlineStatus(ctx context.Context) {
 	response, err = client.Do(request)
 	if err != nil {
 		// if we fail, something is really weird
-		updateOnlineStatus(StatusSemiOnline, "", "http request failed")
+		updateOnlineStatus(StatusSemiOnline, "", "http request failed to "+parsedHTTPSTestURL.String()+" with error "+err.Error())
 		return
 	}
 	defer response.Body.Close()


### PR DESCRIPTION
This PR fixes the HTTPS online check which always fails with "address already in use" and causes the oneline status to jump between online and semi-online.