### PR TITLE
Fix updating the global profile and other bugs

### DIFF
--- a/profile/config-update.go
+++ b/profile/config-update.go
@@ -71,16 +71,16 @@ func updateGlobalConfigProfile(ctx context.Context, data interface{}) error {
 
 	// fill profile config options
 	for key, value := range cfgStringOptions {
-		profile.Config[key] = value
+		profile.Config[key] = value()
 	}
 	for key, value := range cfgStringArrayOptions {
-		profile.Config[key] = value
+		profile.Config[key] = value()
 	}
 	for key, value := range cfgIntOptions {
-		profile.Config[key] = value
+		profile.Config[key] = value()
 	}
 	for key, value := range cfgBoolOptions {
-		profile.Config[key] = value
+		profile.Config[key] = value()
 	}
 
 	// save profile

--- a/profile/config.go
+++ b/profile/config.go
@@ -211,7 +211,7 @@ Examples:
 	if err != nil {
 		return err
 	}
-	cfgOptionBlockInbound = config.Concurrent.GetAsInt(CfgOptionBlockInboundKey, 6)
+	cfgOptionBlockInbound = config.Concurrent.GetAsInt(CfgOptionBlockInboundKey, 4)
 	cfgIntOptions[CfgOptionBlockInboundKey] = cfgOptionBlockInbound
 
 	// Enforce SPN
@@ -247,7 +247,7 @@ Examples:
 		return err
 	}
 	cfgOptionRemoveOutOfScopeDNS = config.Concurrent.GetAsInt(CfgOptionRemoveOutOfScopeDNSKey, 7)
-	cfgIntOptions[CfgOptionRemoveOutOfScopeDNSKey] = cfgOptionEnforceSPN
+	cfgIntOptions[CfgOptionRemoveOutOfScopeDNSKey] = cfgOptionRemoveOutOfScopeDNS
 
 	// Filter DNS Records that would be blocked
 	err = config.Register(&config.Option{
@@ -265,7 +265,7 @@ Examples:
 		return err
 	}
 	cfgOptionRemoveBlockedDNS = config.Concurrent.GetAsInt(CfgOptionRemoveBlockedDNSKey, 7)
-	cfgIntOptions[CfgOptionRemoveBlockedDNSKey] = cfgOptionEnforceSPN
+	cfgIntOptions[CfgOptionRemoveBlockedDNSKey] = cfgOptionRemoveBlockedDNS
 
 	return nil
 }

--- a/profile/config.go
+++ b/profile/config.go
@@ -2,6 +2,7 @@ package profile
 
 import (
 	"github.com/safing/portbase/config"
+	"github.com/safing/portmaster/status"
 )
 
 // Configuration Keys
@@ -74,13 +75,13 @@ func registerConfiguration() error {
 		Description:     "Auto Permit searches for a relation between an app and the destionation of a connection - if there is a correlation, the connection will be permitted. This setting is negated in order to provide a streamlined user experience, where higher settings are better.",
 		OptType:         config.OptTypeInt,
 		ExternalOptType: "security level",
-		DefaultValue:    4,
+		DefaultValue:    status.SecurityLevelsAll,
 		ValidationRegex: "^(4|6|7)$",
 	})
 	if err != nil {
 		return err
 	}
-	cfgOptionDisableAutoPermit = config.Concurrent.GetAsInt(CfgOptionDisableAutoPermitKey, 4)
+	cfgOptionDisableAutoPermit = config.Concurrent.GetAsInt(CfgOptionDisableAutoPermitKey, int64(status.SecurityLevelsAll))
 	cfgIntOptions[CfgOptionDisableAutoPermitKey] = cfgOptionDisableAutoPermit
 
 	// Endpoint Filter List
@@ -141,13 +142,13 @@ Examples:
 		Description:     "Block connections to your own device, ie. localhost.",
 		OptType:         config.OptTypeInt,
 		ExternalOptType: "security level",
-		DefaultValue:    0,
+		DefaultValue:    status.SecurityLevelOff,
 		ValidationRegex: "^(0|4|6|7)$",
 	})
 	if err != nil {
 		return err
 	}
-	cfgOptionBlockScopeLocal = config.Concurrent.GetAsInt(CfgOptionBlockScopeLocalKey, 0)
+	cfgOptionBlockScopeLocal = config.Concurrent.GetAsInt(CfgOptionBlockScopeLocalKey, int64(status.SecurityLevelOff))
 	cfgIntOptions[CfgOptionBlockScopeLocalKey] = cfgOptionBlockScopeLocal
 
 	// Block Scope LAN
@@ -157,13 +158,13 @@ Examples:
 		Description:     "Block connections to the Local Area Network.",
 		OptType:         config.OptTypeInt,
 		ExternalOptType: "security level",
-		DefaultValue:    0,
+		DefaultValue:    status.SecurityLevelOff,
 		ValidationRegex: "^(0|4|6|7)$",
 	})
 	if err != nil {
 		return err
 	}
-	cfgOptionBlockScopeLAN = config.Concurrent.GetAsInt(CfgOptionBlockScopeLANKey, 0)
+	cfgOptionBlockScopeLAN = config.Concurrent.GetAsInt(CfgOptionBlockScopeLANKey, int64(status.SecurityLevelOff))
 	cfgIntOptions[CfgOptionBlockScopeLANKey] = cfgOptionBlockScopeLAN
 
 	// Block Scope Internet
@@ -173,13 +174,13 @@ Examples:
 		Description:     "Block connections to the Internet.",
 		OptType:         config.OptTypeInt,
 		ExternalOptType: "security level",
-		DefaultValue:    0,
+		DefaultValue:    status.SecurityLevelOff,
 		ValidationRegex: "^(0|4|6|7)$",
 	})
 	if err != nil {
 		return err
 	}
-	cfgOptionBlockScopeInternet = config.Concurrent.GetAsInt(CfgOptionBlockScopeInternetKey, 0)
+	cfgOptionBlockScopeInternet = config.Concurrent.GetAsInt(CfgOptionBlockScopeInternetKey, int64(status.SecurityLevelOff))
 	cfgIntOptions[CfgOptionBlockScopeInternetKey] = cfgOptionBlockScopeInternet
 
 	// Block Peer to Peer Connections
@@ -189,13 +190,13 @@ Examples:
 		Description:     "Block peer to peer connections. These are connections that are established directly to an IP address on the Internet without resolving a domain name via DNS first.",
 		OptType:         config.OptTypeInt,
 		ExternalOptType: "security level",
-		DefaultValue:    7,
+		DefaultValue:    status.SecurityLevelsAll,
 		ValidationRegex: "^(4|6|7)$",
 	})
 	if err != nil {
 		return err
 	}
-	cfgOptionBlockP2P = config.Concurrent.GetAsInt(CfgOptionBlockP2PKey, 7)
+	cfgOptionBlockP2P = config.Concurrent.GetAsInt(CfgOptionBlockP2PKey, int64(status.SecurityLevelsAll))
 	cfgIntOptions[CfgOptionBlockP2PKey] = cfgOptionBlockP2P
 
 	// Block Inbound Connections
@@ -205,13 +206,13 @@ Examples:
 		Description:     "Block inbound connections to your device. This will usually only be the case if you are running a network service or are using peer to peer software.",
 		OptType:         config.OptTypeInt,
 		ExternalOptType: "security level",
-		DefaultValue:    4,
+		DefaultValue:    status.SecurityLevelsHighAndExtreme,
 		ValidationRegex: "^(4|6|7)$",
 	})
 	if err != nil {
 		return err
 	}
-	cfgOptionBlockInbound = config.Concurrent.GetAsInt(CfgOptionBlockInboundKey, 4)
+	cfgOptionBlockInbound = config.Concurrent.GetAsInt(CfgOptionBlockInboundKey, int64(status.SecurityLevelsHighAndExtreme))
 	cfgIntOptions[CfgOptionBlockInboundKey] = cfgOptionBlockInbound
 
 	// Enforce SPN
@@ -222,13 +223,13 @@ Examples:
 		OptType:         config.OptTypeInt,
 		ReleaseLevel:    config.ReleaseLevelExperimental,
 		ExternalOptType: "security level",
-		DefaultValue:    0,
+		DefaultValue:    status.SecurityLevelOff,
 		ValidationRegex: "^(0|4|6|7)$",
 	})
 	if err != nil {
 		return err
 	}
-	cfgOptionEnforceSPN = config.Concurrent.GetAsInt(CfgOptionEnforceSPNKey, 0)
+	cfgOptionEnforceSPN = config.Concurrent.GetAsInt(CfgOptionEnforceSPNKey, int64(status.SecurityLevelOff))
 	cfgIntOptions[CfgOptionEnforceSPNKey] = cfgOptionEnforceSPN
 
 	// Filter Out-of-Scope DNS Records
@@ -240,13 +241,13 @@ Examples:
 		ExpertiseLevel:  config.ExpertiseLevelExpert,
 		ReleaseLevel:    config.ReleaseLevelBeta,
 		ExternalOptType: "security level",
-		DefaultValue:    7,
+		DefaultValue:    status.SecurityLevelsAll,
 		ValidationRegex: "^(7|6|4)$",
 	})
 	if err != nil {
 		return err
 	}
-	cfgOptionRemoveOutOfScopeDNS = config.Concurrent.GetAsInt(CfgOptionRemoveOutOfScopeDNSKey, 7)
+	cfgOptionRemoveOutOfScopeDNS = config.Concurrent.GetAsInt(CfgOptionRemoveOutOfScopeDNSKey, int64(status.SecurityLevelsAll))
 	cfgIntOptions[CfgOptionRemoveOutOfScopeDNSKey] = cfgOptionRemoveOutOfScopeDNS
 
 	// Filter DNS Records that would be blocked
@@ -258,13 +259,13 @@ Examples:
 		ExpertiseLevel:  config.ExpertiseLevelExpert,
 		ReleaseLevel:    config.ReleaseLevelBeta,
 		ExternalOptType: "security level",
-		DefaultValue:    7,
+		DefaultValue:    status.SecurityLevelsAll,
 		ValidationRegex: "^(7|6|4)$",
 	})
 	if err != nil {
 		return err
 	}
-	cfgOptionRemoveBlockedDNS = config.Concurrent.GetAsInt(CfgOptionRemoveBlockedDNSKey, 7)
+	cfgOptionRemoveBlockedDNS = config.Concurrent.GetAsInt(CfgOptionRemoveBlockedDNSKey, int64(status.SecurityLevelsAll))
 	cfgIntOptions[CfgOptionRemoveBlockedDNSKey] = cfgOptionRemoveBlockedDNS
 
 	return nil

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -110,7 +110,7 @@ func (profile *Profile) parseConfig() error {
 	var err error
 	var lastErr error
 
-	action, ok := profile.configPerspective.GetAsString(CfgOptionBlockInboundKey)
+	action, ok := profile.configPerspective.GetAsString(CfgOptionDefaultActionKey)
 	if ok {
 		switch action {
 		case "permit":

--- a/resolver/config.go
+++ b/resolver/config.go
@@ -120,8 +120,8 @@ func prepConfig() error {
 		ExpertiseLevel:  config.ExpertiseLevelExpert,
 		ReleaseLevel:    config.ReleaseLevelStable,
 		ExternalOptType: "security level",
-		DefaultValue:    6,
-		ValidationRegex: "^(7|6|4)$",
+		DefaultValue:    status.SecurityLevelsHighAndExtreme,
+		ValidationRegex: "^(4|6|7)$",
 	})
 	if err != nil {
 		return err
@@ -136,8 +136,8 @@ func prepConfig() error {
 		ExpertiseLevel:  config.ExpertiseLevelExpert,
 		ReleaseLevel:    config.ReleaseLevelStable,
 		ExternalOptType: "security level",
-		DefaultValue:    4,
-		ValidationRegex: "^(7|6|4)$",
+		DefaultValue:    status.SecurityLevelsHighAndExtreme,
+		ValidationRegex: "^(4|6|7)$",
 	})
 	if err != nil {
 		return err
@@ -152,8 +152,8 @@ func prepConfig() error {
 		ExpertiseLevel:  config.ExpertiseLevelExpert,
 		ReleaseLevel:    config.ReleaseLevelStable,
 		ExternalOptType: "security level",
-		DefaultValue:    6,
-		ValidationRegex: "^(7|6|4)$",
+		DefaultValue:    status.SecurityLevelsHighAndExtreme,
+		ValidationRegex: "^(4|6|7)$",
 	})
 	if err != nil {
 		return err
@@ -168,8 +168,8 @@ func prepConfig() error {
 		ExpertiseLevel:  config.ExpertiseLevelExpert,
 		ReleaseLevel:    config.ReleaseLevelStable,
 		ExternalOptType: "security level",
-		DefaultValue:    7,
-		ValidationRegex: "^(7|6|4)$",
+		DefaultValue:    status.SecurityLevelsAll,
+		ValidationRegex: "^(4|6|7)$",
 	})
 	if err != nil {
 		return err
@@ -184,8 +184,8 @@ func prepConfig() error {
 		ExpertiseLevel:  config.ExpertiseLevelExpert,
 		ReleaseLevel:    config.ReleaseLevelStable,
 		ExternalOptType: "security level",
-		DefaultValue:    6,
-		ValidationRegex: "^(7|6|4)$",
+		DefaultValue:    status.SecurityLevelsHighAndExtreme,
+		ValidationRegex: "^(4|6|7)$",
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Also, set the blocking inbound connections to all security levels - ie. by default incoming connections are always dropped. We can reconsider this in the future, but we don't want to be opening up something without the user knowing.