### PR TITLE
Add VerdictFailed and check for unknown process in nameserver

### DIFF
--- a/firewall/master.go
+++ b/firewall/master.go
@@ -34,11 +34,16 @@ import (
 //    is called with the first packet of a network connection.
 
 // DecideOnConnection makes a decision about a connection.
+// When called, the connection and profile is already locked.
 func DecideOnConnection(conn *network.Connection, pkt packet.Packet) { //nolint:gocognit,gocyclo // TODO
 	// update profiles and check if communication needs reevaluation
 	if conn.UpdateAndCheck() {
 		log.Infof("filter: re-evaluating verdict on %s", conn)
 		conn.Verdict = network.VerdictUndecided
+
+		if conn.Entity != nil {
+			//conn.Entity.ResetLists()
+		}
 	}
 
 	// grant self
@@ -158,7 +163,7 @@ func DecideOnConnection(conn *network.Connection, pkt packet.Packet) { //nolint:
 	result, reason = p.MatchFilterLists(conn.Entity)
 	switch result {
 	case endpoints.Denied:
-		conn.Deny("endpoint in filterlist: " + reason)
+		conn.Deny("endpoint in filterlists: " + reason)
 		return
 	case endpoints.NoMatch:
 		// nothing to do

--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -176,6 +176,18 @@ func handleRequest(ctx context.Context, w dns.ResponseWriter, query *dns.Msg) er
 	// get connection
 	conn := network.NewConnectionFromDNSRequest(ctx, q.FQDN, remoteAddr.IP, uint16(remoteAddr.Port))
 
+	if conn.Process() == nil {
+		tracer.Infof("nameserver: failed to find process for request %s, returning NXDOMAIN", conn)
+		returnNXDomain(w, query)
+		return nil
+	}
+
+	if conn.Process().Profile() == nil {
+		tracer.Infof("nameserver: process %s does not have a profile associated, returning NXDOMAIN", conn.Process())
+		returnNXDomain(w, query)
+		return nil
+	}
+
 	// save security level to query
 	q.SecurityLevel = conn.Process().Profile().SecurityLevel()
 

--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -176,15 +176,10 @@ func handleRequest(ctx context.Context, w dns.ResponseWriter, query *dns.Msg) er
 	// get connection
 	conn := network.NewConnectionFromDNSRequest(ctx, q.FQDN, remoteAddr.IP, uint16(remoteAddr.Port))
 
-	if conn.Process() == nil {
+	if conn.Process().Profile() == nil {
 		tracer.Infof("nameserver: failed to find process for request %s, returning NXDOMAIN", conn)
 		returnNXDomain(w, query)
-		return nil
-	}
-
-	if conn.Process().Profile() == nil {
-		tracer.Infof("nameserver: process %s does not have a profile associated, returning NXDOMAIN", conn.Process())
-		returnNXDomain(w, query)
+		conn.Save() // save blocked request
 		return nil
 	}
 

--- a/network/connection.go
+++ b/network/connection.go
@@ -198,6 +198,16 @@ func (conn *Connection) Deny(reason string) {
 	}
 }
 
+// Failed marks the connection with VerdictFailed and stores the reason.
+func (conn *Connection) Failed(reason string) {
+	if conn.SetVerdict(VerdictFailed) {
+		conn.Reason = reason
+		log.Infof("filter: dropping connection %s because of an internal error: %s", conn, reason)
+	} else {
+		log.Warningf("filter: tried to drop %s due to error but current verdict is %s", conn, conn.Verdict)
+	}
+}
+
 // SetVerdict sets a new verdict for the connection, making sure it does not interfere with previous verdicts.
 func (conn *Connection) SetVerdict(newVerdict Verdict) (ok bool) {
 	if newVerdict >= conn.Verdict {

--- a/network/status.go
+++ b/network/status.go
@@ -13,6 +13,7 @@ const (
 	VerdictDrop                Verdict = 4
 	VerdictRerouteToNameserver Verdict = 5
 	VerdictRerouteToTunnel     Verdict = 6
+	VerdictFailed              Verdict = 7
 )
 
 func (v Verdict) String() string {
@@ -31,6 +32,8 @@ func (v Verdict) String() string {
 		return "RerouteToNameserver"
 	case VerdictRerouteToTunnel:
 		return "RerouteToTunnel"
+	case VerdictFailed:
+		return "Failed"
 	default:
 		return "<INVALID VERDICT>"
 	}


### PR DESCRIPTION
This PR fixes a nil pointer dereference in nameserver.go and adds a new `VerdictFailed`. It serves as the base for safing/portmaster-ui#44 which adds the new verdict to the monitor module.