### PR TITLE
Add support to filter sub-domains as well

### DIFF
--- a/firewall/master.go
+++ b/firewall/master.go
@@ -41,9 +41,9 @@ func DecideOnConnection(conn *network.Connection, pkt packet.Packet) { //nolint:
 		log.Infof("filter: re-evaluating verdict on %s", conn)
 		conn.Verdict = network.VerdictUndecided
 
-		//if conn.Entity != nil {
-		//conn.Entity.ResetLists()
-		//}
+		if conn.Entity != nil {
+			conn.Entity.ResetLists()
+		}
 	}
 
 	// grant self

--- a/netenv/online-status.go
+++ b/netenv/online-status.go
@@ -201,11 +201,13 @@ func triggerOnlineStatusInvestigation() {
 
 func monitorOnlineStatus(ctx context.Context) error {
 	for {
-		timeout := time.Minute
-		if GetOnlineStatus() != StatusOnline {
-			timeout = time.Second
-			log.Debugf("checking online status again in %s because current status is %s", timeout, GetOnlineStatus())
-		}
+		timeout := 5 * time.Minute
+		/*
+			if GetOnlineStatus() != StatusOnline {
+				timeout = time.Second
+				log.Debugf("checking online status again in %s because current status is %s", timeout, GetOnlineStatus())
+			}
+		*/
 		// wait for trigger
 		select {
 		case <-ctx.Done():

--- a/profile/config.go
+++ b/profile/config.go
@@ -27,6 +27,9 @@ var (
 	CfgOptionFilterListKey = "filter/lists"
 	cfgOptionFilterLists   config.StringArrayOption
 
+	CfgOptionFilterSubDomainsKey = "filter/includeSubdomains"
+	cfgOptionFilterSubDomains    config.IntOption // security level option
+
 	CfgOptionBlockScopeLocalKey = "filter/blockLocal"
 	cfgOptionBlockScopeLocal    config.IntOption // security level option
 
@@ -154,6 +157,21 @@ Examples:
 	}
 	cfgOptionFilterLists = config.Concurrent.GetAsStringArray(CfgOptionFilterListKey, []string{})
 	cfgStringArrayOptions[CfgOptionFilterListKey] = cfgOptionFilterLists
+
+	err = config.Register(&config.Option{
+		Name:            "Filter SubDomains",
+		Key:             CfgOptionFilterSubDomainsKey,
+		Description:     "Also filter sub-domains if a parent domain is blocked by a filter list",
+		OptType:         config.OptTypeInt,
+		ExternalOptType: "security level",
+		DefaultValue:    status.SecurityLevelOff,
+		ValidationRegex: "^(0|4|6|7)$",
+	})
+	if err != nil {
+		return err
+	}
+	cfgOptionFilterSubDomains = config.Concurrent.GetAsInt(CfgOptionFilterSubDomainsKey, int64(status.SecurityLevelOff))
+	cfgIntOptions[CfgOptionFilterSubDomainsKey] = cfgOptionFilterSubDomains
 
 	// Block Scope Local
 	err = config.Register(&config.Option{

--- a/profile/profile-layered.go
+++ b/profile/profile-layered.go
@@ -42,6 +42,7 @@ type LayeredProfile struct {
 	EnforceSPN          config.BoolOption
 	RemoveOutOfScopeDNS config.BoolOption
 	RemoveBlockedDNS    config.BoolOption
+	FilterSubDomains    config.BoolOption
 }
 
 // NewLayeredProfile returns a new layered profile based on the given local profile.
@@ -92,6 +93,10 @@ func NewLayeredProfile(localProfile *Profile) *LayeredProfile {
 	new.RemoveBlockedDNS = new.wrapSecurityLevelOption(
 		CfgOptionRemoveBlockedDNSKey,
 		cfgOptionRemoveBlockedDNS,
+	)
+	new.FilterSubDomains = new.wrapSecurityLevelOption(
+		CfgOptionFilterSubDomainsKey,
+		cfgOptionFilterSubDomains,
 	)
 
 	// TODO: load linked profiles.
@@ -220,6 +225,8 @@ func (lp *LayeredProfile) MatchServiceEndpoint(entity *intel.Entity) (result end
 // MatchFilterLists matches the entity against the set of filter
 // lists.
 func (lp *LayeredProfile) MatchFilterLists(entity *intel.Entity) (result endpoints.EPResult, reason string) {
+	entity.ResolveSubDomainLists(lp.FilterSubDomains())
+
 	lookupMap, hasLists := entity.GetListsMap()
 	if !hasLists {
 		return endpoints.NoMatch, ""


### PR DESCRIPTION
This PR adds a new config option and support to filter sub-domains of blocked/filter domains as well.
It also increases the online-check timeout as a temporary solution.