### PR TITLE
Add support for firefox canary domain for disabling DoH

### DIFF
--- a/firewall/bypassing.go
+++ b/firewall/bypassing.go
@@ -1,0 +1,19 @@
+package firewall
+
+import (
+	"strings"
+
+	"github.com/safing/portmaster/network"
+	"github.com/safing/portmaster/profile/endpoints"
+)
+
+// PreventBypassing checks if the connection should be denied or permitted
+// based on some bypass protection checks.
+func PreventBypassing(conn *network.Connection) (endpoints.EPResult, string) {
+	// Block firefox canary domain to disable DoH
+	if strings.ToLower(conn.Entity.Domain) == "use-application-dns.net." {
+		return endpoints.Denied, "blocked canary domain to prevent enabling DNS-over-HTTPs"
+	}
+
+	return endpoints.NoMatch, ""
+}

--- a/firewall/master.go
+++ b/firewall/master.go
@@ -141,9 +141,19 @@ func DecideOnConnection(conn *network.Connection, pkt packet.Packet) { //nolint:
 		}
 	}
 
+	// check for bypass protection
+	result, reason := p.MatchBypassProtection(conn.Entity)
+	switch result {
+	case endpoints.Denied:
+		conn.Block("bypass prevention: " + reason)
+		return
+	case endpoints.Permitted:
+		conn.Accept("bypass prevention: " + reason)
+		return
+	case endpoints.NoMatch:
+	}
+
 	// check endpoints list
-	var result endpoints.EPResult
-	var reason string
 	if conn.Inbound {
 		result, reason = p.MatchServiceEndpoint(conn.Entity)
 	} else {

--- a/firewall/master.go
+++ b/firewall/master.go
@@ -141,16 +141,21 @@ func DecideOnConnection(conn *network.Connection, pkt packet.Packet) { //nolint:
 		}
 	}
 
-	// check for bypass protection
-	result, reason := p.MatchBypassProtection(conn.Entity)
-	switch result {
-	case endpoints.Denied:
-		conn.Block("bypass prevention: " + reason)
-		return
-	case endpoints.Permitted:
-		conn.Accept("bypass prevention: " + reason)
-		return
-	case endpoints.NoMatch:
+	var result endpoints.EPResult
+	var reason string
+
+	if p.PreventBypassing() {
+		// check for bypass protection
+		result, reason := PreventBypassing(conn)
+		switch result {
+		case endpoints.Denied:
+			conn.Block("bypass prevention: " + reason)
+			return
+		case endpoints.Permitted:
+			conn.Accept("bypass prevention: " + reason)
+			return
+		case endpoints.NoMatch:
+		}
 	}
 
 	// check endpoints list

--- a/intel/entity.go
+++ b/intel/entity.go
@@ -151,7 +151,6 @@ func (e *Entity) getLocation() {
 	e.fetchLocationOnce.Do(func() {
 		// need IP!
 		if e.IP == nil {
-			log.Warningf("intel: cannot get location for %s data without IP", e.Domain)
 			return
 		}
 

--- a/intel/entity.go
+++ b/intel/entity.go
@@ -223,11 +223,11 @@ func (e *Entity) getDomainLists() {
 		var domains = []string{domain}
 		if e.resolveSubDomainLists {
 			domains = splitDomain(domain)
-			log.Debugf("intel: subdomain list resolving is enabled, checking %v", domains)
+			log.Tracef("intel: subdomain list resolving is enabled, checking %v", domains)
 		}
 
 		for _, d := range domains {
-			log.Debugf("intel: loading domain list for %s", d)
+			log.Tracef("intel: loading domain list for %s", d)
 			list, err := filterlists.LookupDomain(d)
 			if err != nil {
 				log.Errorf("intel: failed to get domain blocklists for %s: %s", d, err)
@@ -277,7 +277,7 @@ func (e *Entity) getASNLists() {
 		return
 	}
 
-	log.Debugf("intel: loading ASN list for %d", asn)
+	log.Tracef("intel: loading ASN list for %d", asn)
 	e.loadAsnListOnce.Do(func() {
 		list, err := filterlists.LookupASNString(fmt.Sprintf("%d", asn))
 		if err != nil {
@@ -301,7 +301,7 @@ func (e *Entity) getCountryLists() {
 		return
 	}
 
-	log.Debugf("intel: loading country list for %s", country)
+	log.Tracef("intel: loading country list for %s", country)
 	e.loadCoutryListOnce.Do(func() {
 		list, err := filterlists.LookupCountry(country)
 		if err != nil {
@@ -334,7 +334,7 @@ func (e *Entity) getIPLists() {
 		return
 	}
 
-	log.Debugf("intel: loading IP list for %s", ip)
+	log.Tracef("intel: loading IP list for %s", ip)
 	e.loadIPListOnce.Do(func() {
 		list, err := filterlists.LookupIP(ip)
 

--- a/profile/config.go
+++ b/profile/config.go
@@ -53,6 +53,9 @@ var (
 
 	CfgOptionRemoveBlockedDNSKey = "filter/removeBlockedDNS"
 	cfgOptionRemoveBlockedDNS    config.IntOption // security level option
+
+	CfgOptionBypassProtectionKey = "filter/preventBypassing"
+	cfgOptionBypassProtection    config.IntOption // security level option
 )
 
 func registerConfiguration() error {
@@ -324,6 +327,23 @@ Examples:
 	}
 	cfgOptionRemoveBlockedDNS = config.Concurrent.GetAsInt(CfgOptionRemoveBlockedDNSKey, int64(status.SecurityLevelsAll))
 	cfgIntOptions[CfgOptionRemoveBlockedDNSKey] = cfgOptionRemoveBlockedDNS
+
+	err = config.Register(&config.Option{
+		Name:            "Prevent Bypassing",
+		Key:             CfgOptionBypassProtectionKey,
+		Description:     "Prevent apps from bypassing the privacy filter:\n- Firefox: Disable DNS-over-HTTPs",
+		OptType:         config.OptTypeInt,
+		ExpertiseLevel:  config.ExpertiseLevelUser,
+		ReleaseLevel:    config.ReleaseLevelBeta,
+		ExternalOptType: "security level",
+		DefaultValue:    status.SecurityLevelsAll,
+		ValidationRegex: "^(7|6|4|0)",
+	})
+	if err != nil {
+		return err
+	}
+	cfgOptionBypassProtection = config.Concurrent.GetAsInt((CfgOptionBypassProtectionKey), int64(status.SecurityLevelsAll))
+	cfgIntOptions[CfgOptionBypassProtectionKey] = cfgOptionBypassProtection
 
 	return nil
 }

--- a/profile/config.go
+++ b/profile/config.go
@@ -54,8 +54,8 @@ var (
 	CfgOptionRemoveBlockedDNSKey = "filter/removeBlockedDNS"
 	cfgOptionRemoveBlockedDNS    config.IntOption // security level option
 
-	CfgOptionBypassProtectionKey = "filter/preventBypassing"
-	cfgOptionBypassProtection    config.IntOption // security level option
+	CfgOptionPreventBypassingKey = "filter/preventBypassing"
+	cfgOptionPreventBypassing    config.IntOption // security level option
 )
 
 func registerConfiguration() error {
@@ -330,20 +330,20 @@ Examples:
 
 	err = config.Register(&config.Option{
 		Name:            "Prevent Bypassing",
-		Key:             CfgOptionBypassProtectionKey,
-		Description:     "Prevent apps from bypassing the privacy filter:\n- Firefox: Disable DNS-over-HTTPs",
+		Key:             CfgOptionPreventBypassingKey,
+		Description:     "Prevent apps from bypassing the privacy filter: Firefox by disabling DNS-over-HTTPs",
 		OptType:         config.OptTypeInt,
 		ExpertiseLevel:  config.ExpertiseLevelUser,
 		ReleaseLevel:    config.ReleaseLevelBeta,
 		ExternalOptType: "security level",
 		DefaultValue:    status.SecurityLevelsAll,
-		ValidationRegex: "^(7|6|4|0)",
+		ValidationRegex: "^(7|6|4)",
 	})
 	if err != nil {
 		return err
 	}
-	cfgOptionBypassProtection = config.Concurrent.GetAsInt((CfgOptionBypassProtectionKey), int64(status.SecurityLevelsAll))
-	cfgIntOptions[CfgOptionBypassProtectionKey] = cfgOptionBypassProtection
+	cfgOptionPreventBypassing = config.Concurrent.GetAsInt((CfgOptionPreventBypassingKey), int64(status.SecurityLevelsAll))
+	cfgIntOptions[CfgOptionPreventBypassingKey] = cfgOptionPreventBypassing
 
 	return nil
 }

--- a/profile/profile-layered.go
+++ b/profile/profile-layered.go
@@ -1,6 +1,7 @@
 package profile
 
 import (
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -43,6 +44,7 @@ type LayeredProfile struct {
 	RemoveOutOfScopeDNS config.BoolOption
 	RemoveBlockedDNS    config.BoolOption
 	FilterSubDomains    config.BoolOption
+	PreventBypassing    config.BoolOption
 }
 
 // NewLayeredProfile returns a new layered profile based on the given local profile.
@@ -97,6 +99,10 @@ func NewLayeredProfile(localProfile *Profile) *LayeredProfile {
 	new.FilterSubDomains = new.wrapSecurityLevelOption(
 		CfgOptionFilterSubDomainsKey,
 		cfgOptionFilterSubDomains,
+	)
+	new.PreventBypassing = new.wrapSecurityLevelOption(
+		CfgOptionBypassProtectionKey,
+		cfgOptionBypassProtection,
 	)
 
 	// TODO: load linked profiles.
@@ -224,7 +230,7 @@ func (lp *LayeredProfile) MatchServiceEndpoint(entity *intel.Entity) (result end
 
 // MatchFilterLists matches the entity against the set of filter
 // lists.
-func (lp *LayeredProfile) MatchFilterLists(entity *intel.Entity) (result endpoints.EPResult, reason string) {
+func (lp *LayeredProfile) MatchFilterLists(entity *intel.Entity) (endpoints.EPResult, string) {
 	entity.ResolveSubDomainLists(lp.FilterSubDomains())
 
 	lookupMap, hasLists := entity.GetListsMap()
@@ -248,6 +254,22 @@ func (lp *LayeredProfile) MatchFilterLists(entity *intel.Entity) (result endpoin
 	defer cfgLock.RUnlock()
 	if reason := lookupMap.Match(cfgFilterLists); reason != "" {
 		return endpoints.Denied, reason
+	}
+
+	return endpoints.NoMatch, ""
+}
+
+// MatchBypassProtection checks if the entity should be denied or permitted
+// based on some bypass protection checks.
+func (lp *LayeredProfile) MatchBypassProtection(entity *intel.Entity) (endpoints.EPResult, string) {
+	if !lp.PreventBypassing() {
+		return endpoints.NoMatch, ""
+	}
+
+	// Block firefox canary domain to disable DoH
+	if strings.ToLower(entity.Domain) == "use-application-dns.net." {
+		log.Warningf("bypass protection for firefox canary")
+		return endpoints.Denied, "Firefox canary domain"
 	}
 
 	return endpoints.NoMatch, ""

--- a/profile/profile-layered.go
+++ b/profile/profile-layered.go
@@ -1,7 +1,6 @@
 package profile
 
 import (
-	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -101,8 +100,8 @@ func NewLayeredProfile(localProfile *Profile) *LayeredProfile {
 		cfgOptionFilterSubDomains,
 	)
 	new.PreventBypassing = new.wrapSecurityLevelOption(
-		CfgOptionBypassProtectionKey,
-		cfgOptionBypassProtection,
+		CfgOptionPreventBypassingKey,
+		cfgOptionPreventBypassing,
 	)
 
 	// TODO: load linked profiles.
@@ -254,22 +253,6 @@ func (lp *LayeredProfile) MatchFilterLists(entity *intel.Entity) (endpoints.EPRe
 	defer cfgLock.RUnlock()
 	if reason := lookupMap.Match(cfgFilterLists); reason != "" {
 		return endpoints.Denied, reason
-	}
-
-	return endpoints.NoMatch, ""
-}
-
-// MatchBypassProtection checks if the entity should be denied or permitted
-// based on some bypass protection checks.
-func (lp *LayeredProfile) MatchBypassProtection(entity *intel.Entity) (endpoints.EPResult, string) {
-	if !lp.PreventBypassing() {
-		return endpoints.NoMatch, ""
-	}
-
-	// Block firefox canary domain to disable DoH
-	if strings.ToLower(entity.Domain) == "use-application-dns.net." {
-		log.Warningf("bypass protection for firefox canary")
-		return endpoints.Denied, "Firefox canary domain"
 	}
 
 	return endpoints.NoMatch, ""


### PR DESCRIPTION
This PR adds support to block the Mozilla canary domain `use-application-dns.net`. When blocked, firefox does not use DoH by default and instead falls back to normal (insecure) DNS. This is required so the Portmaster can pickup the DNS requests for firewalling and forward it in a secure way.