### PR TITLE
Let decision reasons decide on the DNS reply

### DIFF
--- a/firewall/bypassing.go
+++ b/firewall/bypassing.go
@@ -3,17 +3,18 @@ package firewall
 import (
 	"strings"
 
+	"github.com/safing/portmaster/nameserver/nsutil"
 	"github.com/safing/portmaster/network"
 	"github.com/safing/portmaster/profile/endpoints"
 )
 
 // PreventBypassing checks if the connection should be denied or permitted
 // based on some bypass protection checks.
-func PreventBypassing(conn *network.Connection) (endpoints.EPResult, string) {
+func PreventBypassing(conn *network.Connection) (endpoints.EPResult, string, nsutil.Responder) {
 	// Block firefox canary domain to disable DoH
 	if strings.ToLower(conn.Entity.Domain) == "use-application-dns.net." {
-		return endpoints.Denied, "blocked canary domain to prevent enabling DNS-over-HTTPs"
+		return endpoints.Denied, "blocked canary domain to prevent enabling DNS-over-HTTPs", nsutil.NxDomain()
 	}
 
-	return endpoints.NoMatch, ""
+	return endpoints.NoMatch, "", nil
 }

--- a/firewall/master.go
+++ b/firewall/master.go
@@ -216,13 +216,13 @@ func checkConnectionScope(conn *network.Connection, _ packet.Packet) bool {
 func checkBypassPrevention(conn *network.Connection, _ packet.Packet) bool {
 	if conn.Process().Profile().PreventBypassing() {
 		// check for bypass protection
-		result, reason := PreventBypassing(conn)
+		result, reason, reasonCtx := PreventBypassing(conn)
 		switch result {
 		case endpoints.Denied:
-			conn.Block("bypass prevention: " + reason)
+			conn.BlockWithContext("bypass prevention: "+reason, reasonCtx)
 			return true
 		case endpoints.Permitted:
-			conn.Accept("bypass prevention: " + reason)
+			conn.AcceptWithContext("bypass prevention: "+reason, reasonCtx)
 			return true
 		case endpoints.NoMatch:
 		}

--- a/intel/block_reason.go
+++ b/intel/block_reason.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/safing/portbase/log"
+	"github.com/safing/portmaster/nameserver/nsutil"
 )
 
 // ListMatch represents an entity that has been
@@ -62,9 +63,10 @@ func (br ListBlockReason) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// ToRRs returns a set of dns TXT records that describe the
-// block reason.
-func (br ListBlockReason) ToRRs() []dns.RR {
+// GetExtraRR implements the nsutil.RRProvider interface
+// and adds additional TXT records justifying the reason
+// the request was blocked.
+func (br ListBlockReason) GetExtraRR(_ *dns.Msg, _ string, _ interface{}) []dns.RR {
 	rrs := make([]dns.RR, 0, len(br))
 
 	for _, lm := range br {
@@ -95,3 +97,5 @@ func (br ListBlockReason) ToRRs() []dns.RR {
 
 	return rrs
 }
+
+var _ nsutil.RRProvider = ListBlockReason(nil)

--- a/intel/entity.go
+++ b/intel/entity.go
@@ -261,9 +261,6 @@ func (e *Entity) mergeList(key string, list []string) {
 	}
 
 	e.ListOccurences[key] = mergeStringList(e.ListOccurences[key], list)
-
-	//e.Lists = mergeStringList(e.Lists, list)
-	//e.ListsMap = buildLookupMap(e.Lists)
 }
 
 func (e *Entity) getDomainLists() {
@@ -289,8 +286,6 @@ func (e *Entity) getDomainLists() {
 			for _, domain := range domainsToInspect {
 				subdomains := splitDomain(domain)
 				domains = append(domains, subdomains...)
-
-				log.Tracef("intel: subdomain list resolving is enabled: %s => %v", domains, subdomains)
 			}
 		} else {
 			domains = domainsToInspect
@@ -446,8 +441,8 @@ func (e *Entity) MatchLists(lists []string) bool {
 		}
 	}
 
-	makeDistinct(e.BlockedByLists)
-	makeDistinct(e.BlockedEntities)
+	e.BlockedByLists = makeDistinct(e.BlockedByLists)
+	e.BlockedEntities = makeDistinct(e.BlockedEntities)
 
 	return len(e.BlockedByLists) > 0
 }

--- a/nameserver/nsutil/nsutil.go
+++ b/nameserver/nsutil/nsutil.go
@@ -1,0 +1,92 @@
+package nsutil
+
+import (
+	"github.com/miekg/dns"
+	"github.com/safing/portbase/log"
+)
+
+// Responder defines the interface that any block/deny reason interface
+// may implement to support sending custom DNS responses for a given reason.
+// That is, if a reason context implements the Responder interface the
+// ReplyWithDNS method will be called instead of creating the default
+// zero-ip response.
+type Responder interface {
+	// ReplyWithDNS is called when a DNS response to a DNS message is
+	// crafted because the request is either denied or blocked.
+	ReplyWithDNS(query *dns.Msg, reason string, reasonCtx interface{}) *dns.Msg
+}
+
+// RRProvider defines the interface that any block/deny reason interface
+// may implement to support adding additional DNS resource records to
+// the DNS responses extra (additional) section.
+type RRProvider interface {
+	// GetExtraRR is called when a DNS response to a DNS message is
+	// crafted because the request is either denied or blocked.
+	GetExtraRR(query *dns.Msg, reason string, reasonCtx interface{}) []dns.RR
+}
+
+// ResponderFunc is a convenience type to use a function
+// directly as a Responder.
+type ResponderFunc func(query *dns.Msg, reason string, reasonCtx interface{}) *dns.Msg
+
+// ReplyWithDNS implements the Responder interface and calls rf.
+func (rf ResponderFunc) ReplyWithDNS(query *dns.Msg, reason string, reasonCtx interface{}) *dns.Msg {
+	return rf(query, reason, reasonCtx)
+}
+
+// ZeroIP is a ResponderFunc than replies with either 0.0.0.0 or :: for
+// each A or AAAA question respectively.
+func ZeroIP() ResponderFunc {
+	return func(query *dns.Msg, _ string, _ interface{}) *dns.Msg {
+		m := new(dns.Msg)
+		hasErr := false
+
+		for _, question := range query.Question {
+			var rr dns.RR
+			var err error
+
+			switch question.Qtype {
+			case dns.TypeA:
+				rr, err = dns.NewRR(question.Name + "  0	IN	A		0.0.0.0")
+			case dns.TypeAAAA:
+				rr, err = dns.NewRR(question.Name + "  0	IN	AAAA	::")
+			}
+
+			if err != nil {
+				log.Errorf("nameserver: failed to create zero-ip response for %s: %s", question.Name, err)
+				hasErr = true
+			} else {
+				m.Answer = append(m.Answer, rr)
+			}
+		}
+
+		if hasErr && len(m.Answer) == 0 {
+			m.SetRcode(query, dns.RcodeServerFailure)
+		} else {
+			m.SetRcode(query, dns.RcodeSuccess)
+		}
+
+		return m
+	}
+}
+
+// NxDomain returns a ResponderFunc that replies with NXDOMAIN.
+func NxDomain() ResponderFunc {
+	return func(query *dns.Msg, _ string, _ interface{}) *dns.Msg {
+		return new(dns.Msg).SetRcode(query, dns.RcodeNameError)
+	}
+}
+
+// Refused returns a ResponderFunc that replies with REFUSED.
+func Refused() ResponderFunc {
+	return func(query *dns.Msg, _ string, _ interface{}) *dns.Msg {
+		return new(dns.Msg).SetRcode(query, dns.RcodeRefused)
+	}
+}
+
+// ServeFail returns a ResponderFunc that replies with SERVFAIL.
+func ServeFail() ResponderFunc {
+	return func(query *dns.Msg, _ string, _ interface{}) *dns.Msg {
+		return new(dns.Msg).SetRcode(query, dns.RcodeServerFailure)
+	}
+}

--- a/nameserver/response.go
+++ b/nameserver/response.go
@@ -1,0 +1,36 @@
+package nameserver
+
+import (
+	"github.com/miekg/dns"
+	"github.com/safing/portbase/log"
+	"github.com/safing/portmaster/nameserver/nsutil"
+	"github.com/safing/portmaster/network"
+)
+
+// sendResponse sends a response to query using w. If reasonCtx is not
+// nil and implements either the Responder or RRProvider interface then
+// those functions are used to craft a DNS response. If reasonCtx is nil
+// or does not implement the Responder interface and verdict is not set
+// to failed a ZeroIP response will be sent. If verdict is set to failed
+// then a ServFail will be sent instead.
+func sendResponse(w dns.ResponseWriter, query *dns.Msg, verdict network.Verdict, reason string, reasonCtx interface{}) {
+	responder, ok := reasonCtx.(nsutil.Responder)
+	if !ok {
+		if verdict == network.VerdictFailed {
+			responder = nsutil.ServeFail()
+		} else {
+			responder = nsutil.ZeroIP()
+		}
+	}
+
+	reply := responder.ReplyWithDNS(query, reason, reasonCtx)
+
+	if extra, ok := reasonCtx.(nsutil.RRProvider); ok {
+		rrs := extra.GetExtraRR(query, reason, reasonCtx)
+		reply.Extra = append(reply.Extra, rrs...)
+	}
+
+	if err := w.WriteMsg(reply); err != nil {
+		log.Errorf("nameserver: failed to send response: %s", err)
+	}
+}


### PR DESCRIPTION
This PR changes the `firewall` and `nameserver` modules so any rule match can decide on the DNS response message as well. 
By default, instead of returning `NXDOMAIN` we now return a zero IP to avoid browsers proceeding with search-domain lookups and thus leak blocked domains via Multicast DNS.  Zero IP means that we will respond with `0.0.0.0` or `::` for any IPv4 or IPv6 question respectively. 
This PR also updates the bypassing feature to continue returning NXDOMAIN for the use-application-dns.net canary domain.