### PR TITLE
Fix filterlists module state not being set

### DIFF
--- a/intel/filterlists/module.go
+++ b/intel/filterlists/module.go
@@ -17,6 +17,7 @@ var (
 
 const (
 	filterlistsDisabled              = "filterlists:disabled"
+	filterlistsUpdateFailed          = "filterlists:update-failed"
 	filterlistsStaleDataSurvived     = "filterlists:staledata"
 	filterlistsStaleDataDescr        = "Removing stale filter list records failed. Some connections may be overblocked."
 	filterlistsUpdateInProgress      = "filterlists:update-in-progress"

--- a/intel/filterlists/updater.go
+++ b/intel/filterlists/updater.go
@@ -24,6 +24,8 @@ func tryListUpdate(ctx context.Context) error {
 	if err != nil {
 		if !isLoaded() {
 			module.Error(filterlistsDisabled, err.Error())
+		} else {
+			module.Warning(filterlistsUpdateFailed, err.Error())
 		}
 		return err
 	}


### PR DESCRIPTION
This PR fixes a bug where the module state of filterlists is not set to warning if an error is encountered during a list-update and the cache db is in use.