### PR TITLE
Remove version information from moved file

### DIFF
--- a/updates/upgrader.go
+++ b/updates/upgrader.go
@@ -175,7 +175,6 @@ func upgradeFile(fileToUpgrade string, file *updater.File) error {
 		// test currentVersion for sanity
 		if !rawVersionRegex.MatchString(currentVersion) {
 			log.Tracef("updates: version string returned by %s is invalid: %s", fileToUpgrade, currentVersion)
-			currentVersion = "0.0.0"
 		}
 
 		// try removing old version

--- a/updates/upgrader.go
+++ b/updates/upgrader.go
@@ -192,7 +192,7 @@ func upgradeFile(fileToUpgrade string, file *updater.File) error {
 				registry.TmpDir().Path,
 				fmt.Sprintf(
 					"%s-%d%s",
-					updater.GetVersionedPath(filepath.Base(fileToUpgrade), currentVersion),
+					filepath.Base(fileToUpgrade),
 					time.Now().UTC().Unix(),
 					upgradedSuffix,
 				),


### PR DESCRIPTION
Otherwise the file is being picked up by the update registry scan.