### PR TITLE
Fix incoming TCP connection direction

### DIFF
--- a/network/state/lookup.go
+++ b/network/state/lookup.go
@@ -107,7 +107,7 @@ func (table *tcpTable) lookup(pktInfo *packet.Info) (
 		}
 	}
 
-	return socket.UnidentifiedProcessID, false, ErrConnectionNotFound
+	return socket.UnidentifiedProcessID, pktInfo.Inbound, ErrConnectionNotFound
 }
 
 func (table *udpTable) lookup(pktInfo *packet.Info) (

--- a/process/find.go
+++ b/process/find.go
@@ -2,17 +2,11 @@ package process
 
 import (
 	"context"
-	"errors"
 
 	"github.com/safing/portmaster/network/state"
 
 	"github.com/safing/portbase/log"
 	"github.com/safing/portmaster/network/packet"
-)
-
-// Errors
-var (
-	ErrProcessNotFound = errors.New("could not find process in system state tables")
 )
 
 // GetProcessByConnection returns the process that owns the described connection.
@@ -27,7 +21,7 @@ func GetProcessByConnection(ctx context.Context, pktInfo *packet.Info) (process 
 	pid, connInbound, err = state.Lookup(pktInfo)
 	if err != nil {
 		log.Tracer(ctx).Debugf("process: failed to find PID of connection: %s", err)
-		return nil, connInbound, err
+		return nil, pktInfo.Inbound, err
 	}
 
 	process, err = GetOrFindPrimaryProcess(ctx, pid)


### PR DESCRIPTION
This fixes a bug where incoming TCP connections without a matching process would be falsely classified as an outgoing connection.