### PR TITLE
Shorten caching for empty success responses.

### DIFF
--- a/resolver/resolver-tcp.go
+++ b/resolver/resolver-tcp.go
@@ -479,10 +479,6 @@ func (mgr *tcpResolverConnMgr) handleQueryResponse(conn *dns.Conn, msg *dns.Msg)
 
 	// persist to database
 	rrCache := inFlight.MakeCacheRecord(msg)
-	if !rrCache.Cacheable() {
-		return
-	}
-
 	rrCache.Clean(minTTL)
 	err := rrCache.Save()
 	if err != nil {

--- a/resolver/rrcache.go
+++ b/resolver/rrcache.go
@@ -85,6 +85,12 @@ func (rrCache *RRCache) Clean(minExpires uint32) {
 		lowestTTL = maxTTL
 	}
 
+	// Adjust return code if there are no answers
+	if rrCache.RCode == dns.RcodeSuccess &&
+		len(rrCache.Answer) == 0 {
+		rrCache.RCode = dns.RcodeNameError
+	}
+
 	// shorten caching
 	switch {
 	case rrCache.RCode != dns.RcodeSuccess:


### PR DESCRIPTION
Note:
```
if !rrCache.Cacheable() {
	return
}
```
is included in `rrCache.Save()`