### PR TITLE
Check binary path of PID lock

### DIFF
--- a/cmds/portmaster-start/lock.go
+++ b/cmds/portmaster-start/lock.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -34,10 +35,16 @@ func checkAndCreateInstanceLock(name string) (pid int32, err error) {
 
 	// Check if process exists.
 	p, err := processInfo.NewProcess(int32(parsedPid))
-	if err != nil {
+	switch {
+	case err == nil:
+		// Process exists, continue.
+	case errors.Is(err, processInfo.ErrorProcessNotRunning):
 		// A process with the locked PID does not exist.
 		// This is expected, so we can continue normally.
 		return 0, createInstanceLock(lockFilePath)
+	default:
+		// There was an internal error getting the process.
+		return 0, err
 	}
 
 	// Get the process paths and evaluate and clean them.

--- a/cmds/portmaster-start/run.go
+++ b/cmds/portmaster-start/run.go
@@ -130,7 +130,10 @@ func run(opts *Options, cmdArgs []string) (err error) {
 
 	// check for duplicate instances
 	if opts.ShortIdentifier == "core" || opts.ShortIdentifier == "hub" {
-		pid, _ := checkAndCreateInstanceLock(opts.ShortIdentifier)
+		pid, err := checkAndCreateInstanceLock(opts.ShortIdentifier)
+		if err != nil {
+			return fmt.Errorf("failed to exec lock: %w", err)
+		}
 		if pid != 0 {
 			return fmt.Errorf("another instance of %s is already running: PID %d", opts.Name, pid)
 		}


### PR DESCRIPTION
Fixes #230.

Heads up! Requires change in `portbase/utils/atomic.go`:
```
	// Version is fixed to commit 353f8196982447d8b12c64f69530e657331e3dbc.
	// The follow-up commit removes Windows support.
	// TOOD: Check how we want to handle this in the future, possibly ingest
	// needed functionality into here.
	"github.com/google/renameio"
```

Will be committed with all the updated go.mod files.