### PR TITLE
Add fast network table lookup

### DIFF
--- a/firewall/master.go
+++ b/firewall/master.go
@@ -145,7 +145,7 @@ func checkSelfCommunication(ctx context.Context, conn *network.Connection, pkt p
 				SrcPort:  pktInfo.SrcPort,
 				Dst:      pktInfo.Dst,
 				DstPort:  pktInfo.DstPort,
-			})
+			}, true)
 			if err != nil {
 				log.Tracer(ctx).Warningf("filter: failed to find local peer process PID: %s", err)
 			} else {

--- a/nameserver/takeover.go
+++ b/nameserver/takeover.go
@@ -78,7 +78,7 @@ func takeover(resolverIP net.IP, resolverPort uint16) (int, error) {
 		SrcPort:  0,   // do not record direction
 		Dst:      resolverIP,
 		DstPort:  resolverPort,
-	})
+	}, true)
 	if err != nil {
 		// there may be nothing listening on :53
 		return 0, nil

--- a/process/find.go
+++ b/process/find.go
@@ -19,9 +19,13 @@ func GetProcessByConnection(ctx context.Context, pktInfo *packet.Info) (process 
 		return GetUnidentifiedProcess(ctx), pktInfo.Inbound, nil
 	}
 
+	// Use fast search for inbound packets, as the listening socket should
+	// already be there for a while now.
+	fastSearch := pktInfo.Inbound
+
 	log.Tracer(ctx).Tracef("process: getting pid from system network state")
 	var pid int
-	pid, connInbound, err = state.Lookup(pktInfo)
+	pid, connInbound, err = state.Lookup(pktInfo, fastSearch)
 	if err != nil {
 		log.Tracer(ctx).Debugf("process: failed to find PID of connection: %s", err)
 		return nil, pktInfo.Inbound, err


### PR DESCRIPTION
This improves handling speed for network packets for which a listener might exist. These lookups do not need such extensive looking, as listeners should normally be already in the tables.

Possibly fixes #258 and #259.