### PR TITLE
Automatically fix chrome-sandbox permissions on older kernels

### DIFF
--- a/cmds/portmaster-start/run.go
+++ b/cmds/portmaster-start/run.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/safing/portmaster/updates/helper"
 	"github.com/spf13/cobra"
 	"github.com/tevino/abool"
 )
@@ -283,7 +284,9 @@ func persistOutputStreams(opts *Options, version string, cmd *exec.Cmd) (chan st
 }
 
 func execute(opts *Options, args []string) (cont bool, err error) {
-	file, err := registry.GetFile(platform(opts.Identifier))
+	file, err := registry.GetFile(
+		helper.PlatformIdentifier(opts.Identifier),
+	)
 	if err != nil {
 		return true, fmt.Errorf("could not get component: %w", err)
 	}

--- a/cmds/portmaster-start/show.go
+++ b/cmds/portmaster-start/show.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/safing/portmaster/updates/helper"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +31,9 @@ func show(opts *Options, cmdArgs []string) error {
 		opts.Identifier += exeSuffix
 	}
 
-	file, err := registry.GetFile(platform(opts.Identifier))
+	file, err := registry.GetFile(
+		helper.PlatformIdentifier(opts.Identifier),
+	)
 	if err != nil {
 		return fmt.Errorf("could not get component: %s", err)
 	}

--- a/updates/get.go
+++ b/updates/get.go
@@ -1,19 +1,15 @@
 package updates
 
 import (
-	"fmt"
 	"path"
-	"runtime"
 
 	"github.com/safing/portbase/updater"
+	"github.com/safing/portmaster/updates/helper"
 )
 
 // GetPlatformFile returns the latest platform specific file identified by the given identifier.
 func GetPlatformFile(identifier string) (*updater.File, error) {
-	identifier = path.Join(fmt.Sprintf("%s_%s", runtime.GOOS, runtime.GOARCH), identifier)
-	// From https://golang.org/pkg/runtime/#GOARCH
-	// GOOS is the running program's operating system target: one of darwin, freebsd, linux, and so on.
-	// GOARCH is the running program's architecture target: one of 386, amd64, arm, s390x, and so on.
+	identifier = helper.PlatformIdentifier(identifier)
 
 	file, err := registry.GetFile(identifier)
 	if err != nil {

--- a/updates/helper/electron.go
+++ b/updates/helper/electron.go
@@ -1,0 +1,84 @@
+package helper
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/safing/portbase/log"
+	"github.com/safing/portbase/updater"
+)
+
+var pmElectronUpdate *updater.File
+
+// EnsureChromeSandboxPermissions makes sure the chrome-sandbox distributed
+// by our app-electron package has the SUID bit set on systems that do not
+// allow unprivileged CLONE_NEWUSER (clone(3)).
+// On non-linux systems or systems that have kernel.unprivileged_userns_clone
+// set to 1 EnsureChromeSandboPermissions is a NO-OP
+func EnsureChromeSandboxPermissions(reg *updater.ResourceRegistry) error {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+
+	if checkSysctl("kernel.unprivileged_userns_clone", '1') {
+		log.Infof("Kernel support for unprivileged USERNS_CLONE enabled.")
+		return nil
+	}
+
+	if pmElectronUpdate != nil && !pmElectronUpdate.UpgradeAvailable() {
+		return nil
+	}
+	identifier := PlatformIdentifier("app/portmaster-app.zip")
+
+	log.Infof("Kernel support for unprivileged USERNS_CLONE disabled.")
+
+	var err error
+	pmElectronUpdate, err = reg.GetFile(identifier)
+	if err != nil {
+		return err
+	}
+	unpackedPath := strings.TrimSuffix(
+		pmElectronUpdate.Path(),
+		filepath.Ext(pmElectronUpdate.Path()),
+	)
+	sandboxFile := filepath.Join(unpackedPath, "chrome-sandbox")
+	if err := os.Chmod(sandboxFile, 0755|os.ModeSetuid); err != nil {
+		return err
+	}
+	log.Infof("Fixed SUID permissions for chrome-sandbox")
+
+	return nil
+}
+
+// PlatformIdentifier converts identifier for the current platform.
+func PlatformIdentifier(identifier string) string {
+	// From https://golang.org/pkg/runtime/#GOARCH
+	// GOOS is the running program's operating system target: one of darwin, freebsd, linux, and so on.
+	// GOARCH is the running program's architecture target: one of 386, amd64, arm, s390x, and so on.
+	return fmt.Sprintf("%s_%s/%s", runtime.GOOS, runtime.GOARCH, identifier)
+}
+
+func checkSysctl(setting string, value byte) bool {
+	c, err := sysctl(setting)
+	if err != nil {
+		return false
+	}
+	if len(c) < 1 {
+		return false
+	}
+	return c[0] == value
+}
+
+func sysctl(setting string) ([]byte, error) {
+	parts := append([]string{"/proc", "sys"}, strings.Split(setting, ".")...)
+	path := filepath.Join(parts...)
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}

--- a/updates/upgrader.go
+++ b/updates/upgrader.go
@@ -21,6 +21,7 @@ import (
 	"github.com/safing/portbase/notifications"
 	"github.com/safing/portbase/rng"
 	"github.com/safing/portbase/updater"
+	"github.com/safing/portmaster/updates/helper"
 )
 
 const (
@@ -65,14 +66,16 @@ func upgrader(_ context.Context, _ interface{}) error {
 	binBaseName := strings.Split(filepath.Base(os.Args[0]), "_")[0]
 	switch binBaseName {
 	case "portmaster-core":
-		err = upgradeCoreNotify()
-		if err != nil {
+		if err := upgradeCoreNotify(); err != nil {
 			log.Warningf("updates: failed to notify about core upgrade: %s", err)
 		}
 
+		if err := helper.EnsureChromeSandboxPermissions(registry); err != nil {
+			log.Warningf("updates: failed to handle electron upgrade: %s", err)
+		}
+
 	case "spn-hub":
-		err = upgradeHub()
-		if err != nil {
+		if err := upgradeHub(); err != nil {
 			log.Warningf("updates: failed to initiate hub upgrade: %s", err)
 		}
 	}


### PR DESCRIPTION
Fix chrome-sandbox permissions after every update and when portmaster-start is executed in the context of the installer. This is required as we plan to **not start** the portmaster service automatically and instead tell the user when starting the UI (which would fail without this fix).