### PR TITLE
Improve nameserver and performance when in failing network condition

### DIFF
--- a/compat/notify.go
+++ b/compat/notify.go
@@ -116,7 +116,7 @@ func (issue *appIssue) notify(proc *process.Process) {
 		"compat: detected %s issue with %s",
 		strings.ReplaceAll(
 			strings.TrimPrefix(
-				strings.TrimSuffix(issue.id, "-%d"),
+				strings.TrimSuffix(issue.id, "-%s"),
 				"compat:",
 			),
 			"-", " ",

--- a/nameserver/failing.go
+++ b/nameserver/failing.go
@@ -1,0 +1,135 @@
+package nameserver
+
+import (
+	"sync"
+	"time"
+
+	"github.com/safing/portmaster/netenv"
+	"github.com/safing/portmaster/resolver"
+)
+
+type failingQuery struct {
+	// Until specifies until when the query should be regarded as failing.
+	Until time.Time
+
+	// Keep specifies until when the failing status shall be kept.
+	Keep time.Time
+
+	// Times specifies how often this query failed.
+	Times int
+
+	// Err holds the error the query failed with.
+	Err error
+}
+
+const (
+	failingDelay             = 900 * time.Millisecond
+	failingBaseDuration      = 900 * time.Millisecond
+	failingFactorDuration    = 500 * time.Millisecond
+	failingMaxDuration       = 30 * time.Second
+	failingKeepAddedDuration = 10 * time.Second
+)
+
+var (
+	failingQueries                   = make(map[string]*failingQuery)
+	failingQueriesLock               sync.RWMutex
+	failingQueriesNetworkChangedFlag = netenv.GetNetworkChangedFlag()
+)
+
+func checkIfQueryIsFailing(q *resolver.Query) (failingErr error, failingUntil *time.Time) {
+	// If the network changed, reset the failed queries.
+	if failingQueriesNetworkChangedFlag.IsSet() {
+		failingQueriesNetworkChangedFlag.Refresh()
+
+		failingQueriesLock.Lock()
+		defer failingQueriesLock.Unlock()
+
+		// Compiler optimized map reset.
+		for key, _ := range failingQueries {
+			delete(failingQueries, key)
+		}
+
+		return nil, nil
+	}
+
+	failingQueriesLock.RLock()
+	defer failingQueriesLock.RUnlock()
+
+	// Quickly return if map is empty.
+	if len(failingQueries) == 0 {
+		return nil, nil
+	}
+
+	// Check if query failed recently.
+	failing, ok := failingQueries[q.ID()]
+	if !ok {
+		return nil, nil
+	}
+
+	// Check if failing query should still be regarded as failing.
+	if time.Now().After(failing.Until) {
+		return nil, nil
+	}
+
+	// Return failing error and until when it's valid.
+	return failing.Err, &failing.Until
+}
+
+func addFailingQuery(q *resolver.Query, err error) {
+	// Check if we were given an error.
+	if err == nil {
+		return
+	}
+
+	// Exclude reverse and mDNS queries, as they fail _often_ and are usually not
+	// retried quickly.
+	// if strings.HasSuffix(q.FQDN, ".in-addr.arpa.") ||
+	// 	strings.HasSuffix(q.FQDN, ".ip6.arpa.") ||
+	// 	strings.HasSuffix(q.FQDN, ".local.") {
+	// 	return
+	// }
+
+	failingQueriesLock.Lock()
+	defer failingQueriesLock.Unlock()
+
+	failing, ok := failingQueries[q.ID()]
+	if !ok {
+		failing = &failingQuery{Err: err}
+		failingQueries[q.ID()] = failing
+	}
+
+	// Calculate fail duration.
+	// Initial fail duration will be at 900ms, perfect for a normal retry after 1s,
+	// but not any earlier.
+	failDuration := failingBaseDuration + time.Duration(failing.Times)*failingFactorDuration
+	if failDuration > failingMaxDuration {
+		failDuration = failingMaxDuration
+	}
+
+	// Update failing query.
+	failing.Times++
+	failing.Until = time.Now().Add(failDuration)
+	failing.Keep = failing.Until.Add(failingKeepAddedDuration)
+}
+
+func cleanFailingQueries(maxRemove, maxMiss int) {
+	failingQueriesLock.Lock()
+	defer failingQueriesLock.Unlock()
+
+	now := time.Now()
+	for key, failing := range failingQueries {
+		if now.After(failing.Keep) {
+			delete(failingQueries, key)
+
+			maxRemove--
+			if maxRemove == 0 {
+				return
+			}
+		} else {
+			maxMiss--
+			if maxMiss == 0 {
+				return
+			}
+		}
+	}
+}

--- a/network/ports.go
+++ b/network/ports.go
@@ -9,9 +9,7 @@ import (
 // currently unused and is unlikely to be used within the next seconds.
 func GetUnusedLocalPort(protocol uint8) (port uint16, ok bool) {
 	allConns := conns.clone()
-
 	tries := 1000
-	hundredth := tries / 100
 
 	// Try up to 1000 times to find an unused port.
 nextPort:
@@ -25,7 +23,7 @@ nextPort:
 		port := uint16(rN + 10000)
 
 		// Shrink range when we chew through the tries.
-		portRangeStart := port - uint16(100-(i/hundredth))
+		portRangeStart := port - 10
 
 		// Check if the generated port is unused.
 	nextConnection:

--- a/resolver/scopes.go
+++ b/resolver/scopes.go
@@ -77,8 +77,8 @@ var (
 		".168.192.in-addr.arpa.",
 
 		// RFC4193: IPv6 private-address reverse-mapping domains.
-		".d.f.ip6.arpa",
-		".c.f.ip6.arpa",
+		".d.f.ip6.arpa.",
+		".c.f.ip6.arpa.",
 
 		// RFC6761: Special use domains for documentation and testing.
 		".example.",

--- a/updates/main.go
+++ b/updates/main.go
@@ -167,14 +167,11 @@ func start() error {
 // TriggerUpdate queues the update task to execute ASAP.
 func TriggerUpdate(force bool) error {
 	switch {
-	case !module.OnlineSoon():
-		return fmt.Errorf("updates module is disabled")
+	case !module.Online():
+		updateASAP = true
 
 	case !force && !enableUpdates():
 		return fmt.Errorf("automatic updating is disabled")
-
-	case !module.Online():
-		updateASAP = true
 
 	default:
 		forceUpdate.Set()
@@ -189,7 +186,8 @@ func TriggerUpdate(force bool) error {
 // If called, updates are only checked when TriggerUpdate()
 // is called.
 func DisableUpdateSchedule() error {
-	if module.OnlineSoon() {
+	switch module.Status() {
+	case modules.StatusStarting, modules.StatusOnline, modules.StatusStopping:
 		return fmt.Errorf("module already online")
 	}
 


### PR DESCRIPTION
- Block successive failing queries
- Improve online status check triggers and logging
- Improve unused port search to find ports more quickly
- Fix update triggering leading to panic when module has not yet started
- Fix IPv6 private address reverse mapping domains
