### PR TITLE
Fix minor updater related issues and rule comments

### DIFF
--- a/cmds/portmaster-start/update.go
+++ b/cmds/portmaster-start/update.go
@@ -106,9 +106,11 @@ func downloadUpdates() error {
 		return fmt.Errorf("failed to unpack resources: %w", err)
 	}
 
-	// Fix chrome-sandbox permissions
-	if err := helper.EnsureChromeSandboxPermissions(registry); err != nil {
-		return fmt.Errorf("failed to fix electron permissions: %w", err)
+	if !intelOnly {
+		// Fix chrome-sandbox permissions
+		if err := helper.EnsureChromeSandboxPermissions(registry); err != nil {
+			return fmt.Errorf("failed to fix electron permissions: %w", err)
+		}
 	}
 
 	return nil

--- a/cmds/portmaster-start/update.go
+++ b/cmds/portmaster-start/update.go
@@ -11,7 +11,10 @@ import (
 	"github.com/safing/portmaster/updates/helper"
 )
 
-var reset bool
+var (
+	reset     bool
+	intelOnly bool
+)
 
 func init() {
 	rootCmd.AddCommand(updateCmd)
@@ -19,6 +22,7 @@ func init() {
 
 	flags := updateCmd.Flags()
 	flags.BoolVar(&reset, "reset", false, "Delete all resources and re-download the basic set")
+	flags.BoolVar(&intelOnly, "intel-only", false, "Only make downloading intel updates mandatory")
 }
 
 var (
@@ -49,6 +53,11 @@ func indexRequired(cmd *cobra.Command) bool {
 }
 
 func downloadUpdates() error {
+	// Check if only intel data is mandatory.
+	if intelOnly {
+		helper.IntelOnly()
+	}
+
 	// Set required updates.
 	registry.MandatoryUpdates = helper.MandatoryUpdates()
 	registry.AutoUnpack = helper.AutoUnpackUpdates()

--- a/network/netutils/ip.go
+++ b/network/netutils/ip.go
@@ -29,29 +29,43 @@ func GetIPScope(ip net.IP) IPScope { //nolint:gocognit
 		// IPv4
 		switch {
 		case ip4[0] == 127:
-			// 127.0.0.0/8
+			// 127.0.0.0/8 (RFC1918)
 			return HostLocal
 		case ip4[0] == 169 && ip4[1] == 254:
-			// 169.254.0.0/16
+			// 169.254.0.0/16 (RFC3927)
 			return LinkLocal
 		case ip4[0] == 10:
-			// 10.0.0.0/8
+			// 10.0.0.0/8 (RFC1918)
 			return SiteLocal
-		case ip4[0] == 172 && ip4[1]&0xf0 == 16:
-			// 172.16.0.0/12
+		case ip4[0] == 100 && ip4[1]&0b11000000 == 64:
+			// 100.64.0.0/10 (RFC6598)
 			return SiteLocal
+		case ip4[0] == 172 && ip4[1]&0b11110000 == 16:
+			// 172.16.0.0/12 (RFC1918)
+			return SiteLocal
+		case ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 2:
+			// 192.0.2.0/24 (TEST-NET-1, RFC5737)
+			return Invalid
 		case ip4[0] == 192 && ip4[1] == 168:
-			// 192.168.0.0/16
+			// 192.168.0.0/16 (RFC1918)
 			return SiteLocal
+		case ip4[0] == 198 && ip4[1] == 51 && ip4[2] == 100:
+			// 198.51.100.0/24 (TEST-NET-2, RFC5737)
+			return Invalid
+		case ip4[0] == 203 && ip4[1] == 0 && ip4[2] == 113:
+			// 203.0.113.0/24 (TEST-NET-3, RFC5737)
+			return Invalid
 		case ip4[0] == 224:
-			// 224.0.0.0/8
+			// 224.0.0.0/8 (RFC5771)
 			return LocalMulticast
+		case ip4[0] == 233 && ip4[1] == 252 && ip4[2] == 0:
+			// 233.252.0.0/24 (MCAST-TEST-NET; RFC5771, RFC6676)
+			return Invalid
 		case ip4[0] >= 225 && ip4[0] <= 238:
-			// 225.0.0.0/8 - 238.0.0.0/8
+			// 225.0.0.0/8 - 238.0.0.0/8 (RFC5771)
 			return GlobalMulticast
 		case ip4[0] == 239:
-			// 239.0.0.0/8
-			// RFC2365 - https://tools.ietf.org/html/rfc2365
+			// 239.0.0.0/8 (RFC2365)
 			return LocalMulticast
 		case ip4[0] == 255 && ip4[1] == 255 && ip4[2] == 255 && ip4[3] == 255:
 			// 255.255.255.255/32

--- a/profile/endpoints/endpoint.go
+++ b/profile/endpoints/endpoint.go
@@ -208,6 +208,14 @@ func parseEndpoint(value string) (endpoint Endpoint, err error) { //nolint:gocog
 		return nil, fmt.Errorf(`invalid endpoint definition: "%s"`, value)
 	}
 
+	// Remove comment.
+	for i, field := range fields {
+		if strings.HasPrefix(field, "#") {
+			fields = fields[:i]
+			break
+		}
+	}
+
 	// any
 	if endpoint, err = parseTypeAny(fields); endpoint != nil || err != nil {
 		return

--- a/profile/endpoints/endpoints.go
+++ b/profile/endpoints/endpoints.go
@@ -62,11 +62,13 @@ entriesLoop:
 // ListEntryValidationRegex is a regex to bullshit check endpoint list entries.
 var ListEntryValidationRegex = strings.Join([]string{
 	`^(\+|\-) `,                   // Rule verdict.
+	`(! +)?`,                      // Invert matching.
 	`[A-z0-9\.:\-*/]+`,            // Entity matching.
 	`( `,                          // Start of optional matching.
 	`[A-z0-9*]+`,                  // Protocol matching.
 	`(/[A-z0-9]+(\-[A-z0-9]+)?)?`, // Port and port range matching.
-	`)?$`,                         // End of optional matching.
+	`)?`,                          // End of optional matching.
+	`( +#.*)?`,                    // Optional comment.
 }, "")
 
 // ValidateEndpointListConfigOption validates the given value.

--- a/updates/helper/electron.go
+++ b/updates/helper/electron.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,6 +35,9 @@ func EnsureChromeSandboxPermissions(reg *updater.ResourceRegistry) error {
 	var err error
 	pmElectronUpdate, err = reg.GetFile(identifier)
 	if err != nil {
+		if errors.Is(err, updater.ErrNotAvailableLocally) {
+			return nil
+		}
 		return fmt.Errorf("failed to get file: %w", err)
 	}
 

--- a/updates/main.go
+++ b/updates/main.go
@@ -269,7 +269,10 @@ func checkForUpdates(ctx context.Context) (err error) {
 
 func stop() error {
 	if registry != nil {
-		return registry.Cleanup()
+		err := registry.Cleanup()
+		if err != nil {
+			log.Warningf("updates: failed to clean up registry: %s", err)
+		}
 	}
 
 	return stopVersionExport()


### PR DESCRIPTION
- Only warn when registry cleanup fails
- Ignore comments on rule parsing
- Add intel-only flag for initializing intel data only
- Only fix chrome sandbox permission when needed
