### PR TITLE
Add option to disable seamless DNS integration

### DIFF
--- a/compat/selfcheck.go
+++ b/compat/selfcheck.go
@@ -28,12 +28,12 @@ var (
 	systemIntegrationCheckDialNet      = fmt.Sprintf("ip4:%d", uint8(SystemIntegrationCheckProtocol))
 	systemIntegrationCheckDialIP       = SystemIntegrationCheckDstIP.String()
 	systemIntegrationCheckPackets      = make(chan packet.Packet, 1)
-	systemIntegrationCheckWaitDuration = 30 * time.Second
+	systemIntegrationCheckWaitDuration = 20 * time.Second
 
 	// DNSCheckInternalDomainScope is the domain scope to use for dns checks.
 	DNSCheckInternalDomainScope = ".self-check." + resolver.InternalSpecialUseDomain
 	dnsCheckReceivedDomain      = make(chan string, 1)
-	dnsCheckWaitDuration        = 30 * time.Second
+	dnsCheckWaitDuration        = 20 * time.Second
 	dnsCheckAnswerLock          sync.Mutex
 	dnsCheckAnswer              net.IP
 )
@@ -61,7 +61,7 @@ func selfcheck(ctx context.Context) (issue *systemIssue, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create system integration conn: %w", err)
 	}
-	_, err = conn.Write([]byte("SELF-CHECK"))
+	_, err = conn.Write([]byte("PORTMASTER SELF CHECK"))
 	if err != nil {
 		return nil, fmt.Errorf("failed to send system integration packet: %w", err)
 	}
@@ -70,7 +70,7 @@ func selfcheck(ctx context.Context) (issue *systemIssue, err error) {
 	select {
 	case <-systemIntegrationCheckPackets:
 		// Check passed!
-		log.Tracef("compat: self-check #1: system integration check passed")
+		log.Tracer(ctx).Tracef("compat: self-check #1: system integration check passed")
 	case <-time.After(systemIntegrationCheckWaitDuration):
 		return systemIntegrationIssue, fmt.Errorf("self-check #1: system integration check failed: did not receive test packet after %s", systemIntegrationCheckWaitDuration)
 	case <-ctx.Done():
@@ -139,12 +139,12 @@ func selfcheck(ctx context.Context) (issue *systemIssue, err error) {
 	select {
 	case receivedTestDomain := <-dnsCheckReceivedDomain:
 		if receivedTestDomain != randomSubdomain {
-			return systemCompatibilityIssue, fmt.Errorf("self-check #2: dns integration check failed: received unmatching subdomain %q", receivedTestDomain)
+			return systemCompatOrManualDNSIssue(), fmt.Errorf("self-check #2: dns integration check failed: received unmatching subdomain %q", receivedTestDomain)
 		}
 	case <-time.After(dnsCheckWaitDuration):
-		return systemCompatibilityIssue, fmt.Errorf("self-check #2: dns integration check failed: did not receive test query after %s", dnsCheckWaitDuration)
+		return systemCompatOrManualDNSIssue(), fmt.Errorf("self-check #2: dns integration check failed: did not receive test query after %s", dnsCheckWaitDuration)
 	}
-	log.Tracef("compat: self-check #2: dns integration query check passed")
+	log.Tracer(ctx).Tracef("compat: self-check #2: dns integration query check passed")
 
 	// Step 3: Have the nameserver respond with random data in the answer section.
 
@@ -164,7 +164,7 @@ func selfcheck(ctx context.Context) (issue *systemIssue, err error) {
 	if !dnsCheckReturnedIP.Equal(randomAnswer) {
 		return systemCompatibilityIssue, fmt.Errorf("self-check #3: dns integration check failed: received unmatching response %q", dnsCheckReturnedIP)
 	}
-	log.Tracef("compat: self-check #3: dns integration response check passed")
+	log.Tracer(ctx).Tracef("compat: self-check #3: dns integration response check passed")
 
 	return nil, nil
 }

--- a/firewall/bypassing.go
+++ b/firewall/bypassing.go
@@ -43,8 +43,12 @@ func PreventBypassing(ctx context.Context, conn *network.Connection) (endpoints.
 		return endpoints.NoMatch, "", nil
 	}
 
-	// Block bypass attempts using an encrypted DNS server.
+	// Block bypass attempts using an (encrypted) DNS server.
 	switch {
+	case conn.Entity.Port == 53:
+		return endpoints.Denied,
+			"blocked DNS query, manual dns setup required",
+			nsutil.BlockIP()
 	case conn.Entity.Port == 853:
 		// Block connections to port 853 - DNS over TLS.
 		fallthrough

--- a/firewall/config.go
+++ b/firewall/config.go
@@ -23,6 +23,10 @@ var (
 	cfgOptionPermanentVerdictsOrder = 96
 	permanentVerdicts               config.BoolOption
 
+	CfgOptionDNSQueryInterceptionKey   = "filter/dnsQueryInterception"
+	cfgOptionDNSQueryInterceptionOrder = 97
+	dnsQueryInterception               config.BoolOption
+
 	devMode          config.BoolOption
 	apiListenAddress config.StringOption
 )
@@ -45,6 +49,24 @@ func registerConfig() error {
 		return err
 	}
 	permanentVerdicts = config.Concurrent.GetAsBool(CfgOptionPermanentVerdictsKey, true)
+
+	err = config.Register(&config.Option{
+		Name:           "Seamless DNS Integration",
+		Key:            CfgOptionDNSQueryInterceptionKey,
+		Description:    "Intercept and redirect astray DNS queries to the Portmaster's internal DNS server. This enables seamless DNS integration without having to configure the system or other software. However, this may lead to compatibility issues with other software that attempts the same.",
+		OptType:        config.OptTypeBool,
+		ExpertiseLevel: config.ExpertiseLevelDeveloper,
+		ReleaseLevel:   config.ReleaseLevelExperimental,
+		DefaultValue:   true,
+		Annotations: config.Annotations{
+			config.DisplayOrderAnnotation: cfgOptionDNSQueryInterceptionOrder,
+			config.CategoryAnnotation:     "Advanced",
+		},
+	})
+	if err != nil {
+		return err
+	}
+	dnsQueryInterception = config.Concurrent.GetAsBool(CfgOptionDNSQueryInterceptionKey, true)
 
 	err = config.Register(&config.Option{
 		Name:           "Prompt Desktop Notifications",

--- a/firewall/filter.go
+++ b/firewall/filter.go
@@ -4,8 +4,6 @@ import (
 	"github.com/safing/portbase/config"
 	"github.com/safing/portbase/modules"
 	"github.com/safing/portbase/modules/subsystems"
-
-	// Dependency.
 	_ "github.com/safing/portmaster/core"
 	"github.com/safing/spn/captain"
 )

--- a/firewall/interception.go
+++ b/firewall/interception.go
@@ -16,8 +16,6 @@ import (
 	"github.com/safing/portbase/log"
 	"github.com/safing/portbase/modules"
 	"github.com/safing/portmaster/compat"
-
-	// Dependency.
 	_ "github.com/safing/portmaster/core/base"
 	"github.com/safing/portmaster/firewall/inspection"
 	"github.com/safing/portmaster/firewall/interception"
@@ -332,8 +330,9 @@ func initialHandler(conn *network.Connection, pkt packet.Packet) {
 		conn.Accept("connection by Portmaster", noReasonOptionKey)
 		conn.Internal = true
 
-		// Redirect outbound DNS packests,
-	case pkt.IsOutbound() &&
+		// Redirect outbound DNS packets if enabled,
+	case dnsQueryInterception() &&
+		pkt.IsOutbound() &&
 		pkt.Info().DstPort == 53 &&
 		// that don't match the address of our nameserver,
 		nameserverIPMatcherReady.IsSet() &&
@@ -341,7 +340,7 @@ func initialHandler(conn *network.Connection, pkt packet.Packet) {
 		// and are not broadcast queries by us.
 		// Context:
 		// - Unicast queries by the resolver are pre-authenticated.
-		// - Unicast qeries by the compat self-check should be redirected.
+		// - Unicast queries by the compat self-check should be redirected.
 		!(conn.Process().Pid == ownPID &&
 			conn.Entity.IPScope == netutils.LocalMulticast):
 

--- a/firewall/interception/nfqueue_linux.go
+++ b/firewall/interception/nfqueue_linux.go
@@ -46,42 +46,42 @@ type nfQueue interface {
 
 func init() {
 	v4chains = []string{
-		"mangle C170",
-		"mangle C171",
-		"filter C17",
+		"mangle PORTMASTER-C170",
+		"mangle PORTMASTER-C171",
+		"filter PORTMASTER-C17",
 	}
 
 	v4rules = []string{
-		"mangle C170 -j CONNMARK --restore-mark",
-		"mangle C170 -m mark --mark 0 -j NFQUEUE --queue-num 17040 --queue-bypass",
+		"mangle PORTMASTER-C170 -j CONNMARK --restore-mark",
+		"mangle PORTMASTER-C170 -m mark --mark 0 -j NFQUEUE --queue-num 17040 --queue-bypass",
 
-		"mangle C171 -j CONNMARK --restore-mark",
-		"mangle C171 -m mark --mark 0 -j NFQUEUE --queue-num 17140 --queue-bypass",
+		"mangle PORTMASTER-C171 -j CONNMARK --restore-mark",
+		"mangle PORTMASTER-C171 -m mark --mark 0 -j NFQUEUE --queue-num 17140 --queue-bypass",
 
-		"filter C17 -m mark --mark 0 -j DROP",
-		"filter C17 -m mark --mark 1700 -j RETURN",
+		"filter PORTMASTER-C17 -m mark --mark 0 -j DROP",
+		"filter PORTMASTER-C17 -m mark --mark 1700 -j RETURN",
 		// Accepting ICMP packets with mark 1701 is required for rejecting to work,
 		// as the rejection ICMP packet will have the same mark. Blocked ICMP
 		// packets will always result in a drop within the Portmaster.
-		"filter C17 -m mark --mark 1701 -p icmp -j RETURN",
-		"filter C17 -m mark --mark 1701 -j REJECT --reject-with icmp-host-prohibited",
-		"filter C17 -m mark --mark 1702 -j DROP",
-		"filter C17 -j CONNMARK --save-mark",
-		"filter C17 -m mark --mark 1710 -j RETURN",
+		"filter PORTMASTER-C17 -m mark --mark 1701 -p icmp -j RETURN",
+		"filter PORTMASTER-C17 -m mark --mark 1701 -j REJECT --reject-with icmp-host-prohibited",
+		"filter PORTMASTER-C17 -m mark --mark 1702 -j DROP",
+		"filter PORTMASTER-C17 -j CONNMARK --save-mark",
+		"filter PORTMASTER-C17 -m mark --mark 1710 -j RETURN",
 		// Accepting ICMP packets with mark 1711 is required for rejecting to work,
 		// as the rejection ICMP packet will have the same mark. Blocked ICMP
 		// packets will always result in a drop within the Portmaster.
-		"filter C17 -m mark --mark 1711 -p icmp -j RETURN",
-		"filter C17 -m mark --mark 1711 -j REJECT --reject-with icmp-host-prohibited",
-		"filter C17 -m mark --mark 1712 -j DROP",
-		"filter C17 -m mark --mark 1717 -j RETURN",
+		"filter PORTMASTER-C17 -m mark --mark 1711 -p icmp -j RETURN",
+		"filter PORTMASTER-C17 -m mark --mark 1711 -j REJECT --reject-with icmp-host-prohibited",
+		"filter PORTMASTER-C17 -m mark --mark 1712 -j DROP",
+		"filter PORTMASTER-C17 -m mark --mark 1717 -j RETURN",
 	}
 
 	v4once = []string{
-		"mangle OUTPUT -j C170",
-		"mangle INPUT -j C171",
-		"filter OUTPUT -j C17",
-		"filter INPUT -j C17",
+		"mangle OUTPUT -j PORTMASTER-C170",
+		"mangle INPUT -j PORTMASTER-C171",
+		"filter OUTPUT -j PORTMASTER-C17",
+		"filter INPUT -j PORTMASTER-C17",
 		"nat OUTPUT -m mark --mark 1799 -p udp -j DNAT --to 127.0.0.17:53",
 		"nat OUTPUT -m mark --mark 1717 -p tcp -j DNAT --to 127.0.0.17:717",
 		"nat OUTPUT -m mark --mark 1717 -p udp -j DNAT --to 127.0.0.17:717",
@@ -89,36 +89,36 @@ func init() {
 	}
 
 	v6chains = []string{
-		"mangle C170",
-		"mangle C171",
-		"filter C17",
+		"mangle PORTMASTER-C170",
+		"mangle PORTMASTER-C171",
+		"filter PORTMASTER-C17",
 	}
 
 	v6rules = []string{
-		"mangle C170 -j CONNMARK --restore-mark",
-		"mangle C170 -m mark --mark 0 -j NFQUEUE --queue-num 17060 --queue-bypass",
+		"mangle PORTMASTER-C170 -j CONNMARK --restore-mark",
+		"mangle PORTMASTER-C170 -m mark --mark 0 -j NFQUEUE --queue-num 17060 --queue-bypass",
 
-		"mangle C171 -j CONNMARK --restore-mark",
-		"mangle C171 -m mark --mark 0 -j NFQUEUE --queue-num 17160 --queue-bypass",
+		"mangle PORTMASTER-C171 -j CONNMARK --restore-mark",
+		"mangle PORTMASTER-C171 -m mark --mark 0 -j NFQUEUE --queue-num 17160 --queue-bypass",
 
-		"filter C17 -m mark --mark 0 -j DROP",
-		"filter C17 -m mark --mark 1700 -j RETURN",
-		"filter C17 -m mark --mark 1701 -p icmpv6 -j RETURN",
-		"filter C17 -m mark --mark 1701 -j REJECT --reject-with icmp6-adm-prohibited",
-		"filter C17 -m mark --mark 1702 -j DROP",
-		"filter C17 -j CONNMARK --save-mark",
-		"filter C17 -m mark --mark 1710 -j RETURN",
-		"filter C17 -m mark --mark 1711 -p icmpv6 -j RETURN",
-		"filter C17 -m mark --mark 1711 -j REJECT --reject-with icmp6-adm-prohibited",
-		"filter C17 -m mark --mark 1712 -j DROP",
-		"filter C17 -m mark --mark 1717 -j RETURN",
+		"filter PORTMASTER-C17 -m mark --mark 0 -j DROP",
+		"filter PORTMASTER-C17 -m mark --mark 1700 -j RETURN",
+		"filter PORTMASTER-C17 -m mark --mark 1701 -p icmpv6 -j RETURN",
+		"filter PORTMASTER-C17 -m mark --mark 1701 -j REJECT --reject-with icmp6-adm-prohibited",
+		"filter PORTMASTER-C17 -m mark --mark 1702 -j DROP",
+		"filter PORTMASTER-C17 -j CONNMARK --save-mark",
+		"filter PORTMASTER-C17 -m mark --mark 1710 -j RETURN",
+		"filter PORTMASTER-C17 -m mark --mark 1711 -p icmpv6 -j RETURN",
+		"filter PORTMASTER-C17 -m mark --mark 1711 -j REJECT --reject-with icmp6-adm-prohibited",
+		"filter PORTMASTER-C17 -m mark --mark 1712 -j DROP",
+		"filter PORTMASTER-C17 -m mark --mark 1717 -j RETURN",
 	}
 
 	v6once = []string{
-		"mangle OUTPUT -j C170",
-		"mangle INPUT -j C171",
-		"filter OUTPUT -j C17",
-		"filter INPUT -j C17",
+		"mangle OUTPUT -j PORTMASTER-C170",
+		"mangle INPUT -j PORTMASTER-C171",
+		"filter OUTPUT -j PORTMASTER-C17",
+		"filter INPUT -j PORTMASTER-C17",
 		"nat OUTPUT -m mark --mark 1799 -p udp -j DNAT --to [::1]:53",
 		"nat OUTPUT -m mark --mark 1717 -p tcp -j DNAT --to [::1]:717",
 		"nat OUTPUT -m mark --mark 1717 -p udp -j DNAT --to [::1]:717",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/safing/portmaster
 
-go 1.15
+go 1.18
 
 require (
 	github.com/agext/levenshtein v1.2.3

--- a/nameserver/module.go
+++ b/nameserver/module.go
@@ -13,6 +13,7 @@ import (
 	"github.com/safing/portbase/log"
 	"github.com/safing/portbase/modules"
 	"github.com/safing/portbase/modules/subsystems"
+	"github.com/safing/portmaster/compat"
 	"github.com/safing/portmaster/firewall"
 	"github.com/safing/portmaster/netenv"
 )
@@ -52,6 +53,9 @@ func start() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse nameserver listen address: %w", err)
 	}
+
+	// Tell the compat module where we are listening.
+	compat.SetNameserverListenIP(ip1)
 
 	// Get own hostname.
 	hostname, err = os.Hostname()

--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -168,7 +168,7 @@ func handleRequest(ctx context.Context, w dns.ResponseWriter, request *dns.Msg) 
 		}
 
 	default:
-		tracer.Warningf("nameserver: external request for %s%s, ignoring", q.FQDN, q.QType)
+		tracer.Warningf("nameserver: external request from %s for %s%s, ignoring", remoteAddr, q.FQDN, q.QType)
 		return reply(nsutil.Refused("external queries are not permitted"))
 	}
 	conn.Lock()


### PR DESCRIPTION
- Add config option to disable dns query interception
- Block DNS requests if bypass prevention is active
- Show notification about manual DNS setup instead of compatibility notice
- Use more verbose names for iptables chains
