### PR TITLE
Improve support for IPv4 stack, location and geoip improvements

### DIFF
--- a/cmds/portmaster-start/logs.go
+++ b/cmds/portmaster-start/logs.go
@@ -17,7 +17,7 @@ import (
 )
 
 func initializeLogFile(logFilePath string, identifier string, version string) *os.File {
-	logFile, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE, 0o0444)
+	logFile, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE, 0o0440)
 	if err != nil {
 		log.Printf("failed to create log file %s: %s\n", logFilePath, err)
 		return nil

--- a/firewall/dns.go
+++ b/firewall/dns.go
@@ -263,7 +263,7 @@ func UpdateIPsAndCNAMEs(q *resolver.Query, rrCache *resolver.RRCache, conn *netw
 	// Package IPs and CNAMEs into IPInfo structs.
 	for _, ip := range ips {
 		// Never save domain attributions for localhost IPs.
-		if netutils.ClassifyIP(ip) == netutils.HostLocal {
+		if netutils.GetIPScope(ip) == netutils.HostLocal {
 			continue
 		}
 

--- a/firewall/interception/nfq/packet.go
+++ b/firewall/interception/nfq/packet.go
@@ -141,6 +141,13 @@ func (pkt *packet) Drop() error {
 }
 
 func (pkt *packet) PermanentAccept() error {
+	// If the packet is localhost only, do not permanently accept the outgoing
+	// packet, as the packet mark will be copied to the connection mark, which
+	// will stick and it will bypass the incoming queue.
+	if !pkt.Info().Inbound && pkt.Info().Dst.IsLoopback() {
+		return pkt.Accept()
+	}
+
 	return pkt.mark(MarkAcceptAlways)
 }
 

--- a/intel/filterlists/updater.go
+++ b/intel/filterlists/updater.go
@@ -24,6 +24,11 @@ var updateInProgress = abool.New()
 func tryListUpdate(ctx context.Context) error {
 	err := performUpdate(ctx)
 	if err != nil {
+		// Check if we are shutting down.
+		if module.IsStopping() {
+			return nil
+		}
+
 		// Check if the module already has a failure status set. If not, set a
 		// generic one with the returned error.
 		failureStatus, _, _ := module.FailureStatus()

--- a/intel/geoip/lookup.go
+++ b/intel/geoip/lookup.go
@@ -26,3 +26,8 @@ func GetLocation(ip net.IP) (*Location, error) {
 	record.FillMissingInfo()
 	return record, nil
 }
+
+// IsInitialized returns whether the geoip database has been initialized.
+func IsInitialized(v6, wait bool) bool {
+	return worker.GetReader(v6, wait) != nil
+}

--- a/nameserver/module.go
+++ b/nameserver/module.go
@@ -259,7 +259,11 @@ func getListenAddresses(listenAddress string) (ip1, ip2 net.IP, port uint16, err
 	// listen separately for IPv4 and IPv6.
 	if ipString == "localhost" {
 		ip1 = net.IPv4(127, 0, 0, 17)
-		ip2 = net.IPv6loopback
+		if netenv.IPv6Enabled() {
+			ip2 = net.IPv6loopback
+		} else {
+			log.Warningf("nameserver: no IPv6 stack detected, disabling IPv6 nameserver listener")
+		}
 	} else {
 		ip1 = net.ParseIP(ipString)
 		if ip1 == nil {

--- a/netenv/api.go
+++ b/netenv/api.go
@@ -55,7 +55,7 @@ func registerAPIEndpoints() error {
 		Read:      api.PermitUser,
 		BelongsTo: module,
 		StructFunc: func(ar *api.Request) (i interface{}, err error) {
-			return getLocationFromTraceroute()
+			return getLocationFromTraceroute(&DeviceLocations{})
 		},
 		Name:        "Get Approximate Internet Location via Traceroute",
 		Description: "Returns an approximation of where the device is on the Internet using a the traceroute technique.",

--- a/netenv/main.go
+++ b/netenv/main.go
@@ -1,9 +1,10 @@
 package netenv
 
 import (
+	"github.com/tevino/abool"
+
 	"github.com/safing/portbase/log"
 	"github.com/safing/portbase/modules"
-	"github.com/tevino/abool"
 )
 
 // Event Names.

--- a/netenv/main.go
+++ b/netenv/main.go
@@ -1,7 +1,9 @@
 package netenv
 
 import (
+	"github.com/safing/portbase/log"
 	"github.com/safing/portbase/modules"
+	"github.com/tevino/abool"
 )
 
 // Event Names.
@@ -20,6 +22,8 @@ func init() {
 }
 
 func prep() error {
+	checkForIPv6Stack()
+
 	if err := registerAPIEndpoints(); err != nil {
 		return err
 	}
@@ -45,4 +49,23 @@ func start() error {
 	)
 
 	return nil
+}
+
+var ipv6Enabled = abool.NewBool(true)
+
+// IPv6Enabled returns whether the device has an active IPv6 stack.
+// This is only checked once on startup in order to maintain consistency.
+func IPv6Enabled() bool {
+	return ipv6Enabled.IsSet()
+}
+
+func checkForIPv6Stack() {
+	_, v6IPs, err := GetAssignedAddresses()
+	if err != nil {
+		log.Warningf("netenv: failed to get assigned addresses to check for ipv6 stack: %s", err)
+		return
+	}
+
+	// Set IPv6 as enabled if any IPv6 addresses are found.
+	ipv6Enabled.SetTo(len(v6IPs) > 0)
 }

--- a/network/state/lookup.go
+++ b/network/state/lookup.go
@@ -60,7 +60,7 @@ func Lookup(pktInfo *packet.Info, fast bool) (pid int, inbound bool, err error) 
 		return udp6Table.lookup(pktInfo, fast)
 
 	default:
-		return socket.UndefinedProcessID, false, errors.New("unsupported protocol for finding process")
+		return socket.UndefinedProcessID, pktInfo.Inbound, errors.New("unsupported protocol for finding process")
 	}
 }
 

--- a/process/special.go
+++ b/process/special.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/safing/portbase/log"
+	"github.com/safing/portmaster/network/socket"
 	"github.com/safing/portmaster/profile"
 )
 
@@ -27,6 +28,13 @@ const (
 	// NetworkHostProcessID is the PID used for requests served to the network.
 	NetworkHostProcessID = -255
 )
+
+func init() {
+	// Check required matching values.
+	if UndefinedProcessID != socket.UndefinedProcessID {
+		panic("UndefinedProcessID does not match socket.UndefinedProcessID")
+	}
+}
 
 var (
 	// unidentifiedProcess is used for non-attributed outgoing connections.

--- a/profile/config.go
+++ b/profile/config.go
@@ -343,27 +343,6 @@ Important: DNS Requests are only matched against domain and filter list rules, a
 	cfgOptionServiceEndpoints = config.Concurrent.GetAsStringArray(CfgOptionServiceEndpointsKey, defaultIncomingRulesValue)
 	cfgStringArrayOptions[CfgOptionServiceEndpointsKey] = cfgOptionServiceEndpoints
 
-	filterListsHelp := strings.ReplaceAll(`Filter lists contain domains and IP addresses that are known to be used adversarial. The data is collected from many public sources and put into the following categories. In order to active a category, add it's "ID" to the list.
-
-**Ads & Trackers** - ID: "TRAC"  
-Services that track and profile people online, including as ads, analytics and telemetry.
-
-**Malware** - ID: "MAL"  
-Services that are (ab)used for attacking devices through technical means.
-
-**Deception** - ID: "DECEP"  
-Services that trick humans into thinking the service is genuine, while it is not, including phishing, fake news and fraud.
-
-**Bad Stuff (Mixed)** - ID: "BAD"  
-Miscellaneous services that are believed to be harmful to security or privacy, but their exact use is unknown, not categorized, or lists have mixed categories.
-
-**NSFW** - ID: "NSFW"  
-Services that are generally not accepted in work environments, including pornography, violence and gambling.
-
-The lists are automatically updated every hour using incremental updates.  
-[See here](https://github.com/safing/intel-data) for more detail about these lists, their sources and how to help to improve them.
-`, `"`, "`")
-
 	// Filter list IDs
 	defaultFilterListsValue := []string{"TRAC", "MAL", "BAD"}
 	err = config.Register(&config.Option{

--- a/profile/config.go
+++ b/profile/config.go
@@ -258,6 +258,12 @@ Examples: "192.168.0.1 TCP/HTTP", "LAN UDP/50000-55000", "example.com */HTTPS", 
 Important: DNS Requests are only matched against domain and filter list rules, all others require an IP address and are checked only with the following IP connection.
 `, `"`, "`")
 
+	// rulesVerdictNames defines the verdicts names to be used for filter rules.
+	rulesVerdictNames := map[string]string{
+		"-": "Block", // Default.
+		"+": "Allow",
+	}
+
 	// Endpoint Filter List
 	err = config.Register(&config.Option{
 		Name:         "Outgoing Rules",
@@ -268,10 +274,11 @@ Important: DNS Requests are only matched against domain and filter list rules, a
 		OptType:      config.OptTypeStringArray,
 		DefaultValue: []string{},
 		Annotations: config.Annotations{
-			config.StackableAnnotation:    true,
-			config.DisplayHintAnnotation:  endpoints.DisplayHintEndpointList,
-			config.DisplayOrderAnnotation: cfgOptionEndpointsOrder,
-			config.CategoryAnnotation:     "Rules",
+			config.StackableAnnotation:                   true,
+			config.DisplayHintAnnotation:                 endpoints.DisplayHintEndpointList,
+			config.DisplayOrderAnnotation:                cfgOptionEndpointsOrder,
+			config.CategoryAnnotation:                    "Rules",
+			endpoints.EndpointListVerdictNamesAnnotation: rulesVerdictNames,
 		},
 		ValidationRegex: endpoints.ListEntryValidationRegex,
 		ValidationFunc:  endpoints.ValidateEndpointListConfigOption,
@@ -283,6 +290,7 @@ Important: DNS Requests are only matched against domain and filter list rules, a
 	cfgStringArrayOptions[CfgOptionEndpointsKey] = cfgOptionEndpoints
 
 	// Service Endpoint Filter List
+	defaultIncomingRulesValue := []string{"+ Localhost"}
 	err = config.Register(&config.Option{
 		Name:           "Incoming Rules",
 		Key:            CfgOptionServiceEndpointsKey,
@@ -290,13 +298,14 @@ Important: DNS Requests are only matched against domain and filter list rules, a
 		Help:           rulesHelp,
 		Sensitive:      true,
 		OptType:        config.OptTypeStringArray,
-		DefaultValue:   []string{"+ Localhost"},
+		DefaultValue:   defaultIncomingRulesValue,
 		ExpertiseLevel: config.ExpertiseLevelExpert,
 		Annotations: config.Annotations{
-			config.StackableAnnotation:    true,
-			config.DisplayHintAnnotation:  endpoints.DisplayHintEndpointList,
-			config.DisplayOrderAnnotation: cfgOptionServiceEndpointsOrder,
-			config.CategoryAnnotation:     "Rules",
+			config.StackableAnnotation:                   true,
+			config.DisplayHintAnnotation:                 endpoints.DisplayHintEndpointList,
+			config.DisplayOrderAnnotation:                cfgOptionServiceEndpointsOrder,
+			config.CategoryAnnotation:                    "Rules",
+			endpoints.EndpointListVerdictNamesAnnotation: rulesVerdictNames,
 			config.QuickSettingsAnnotation: []config.QuickSetting{
 				{
 					Name:   "SSH",
@@ -313,6 +322,16 @@ Important: DNS Requests are only matched against domain and filter list rules, a
 					Action: config.QuickMergeTop,
 					Value:  []string{"+ * */3389"},
 				},
+				{
+					Name:   "Allow all from LAN",
+					Action: config.QuickMergeTop,
+					Value:  []string{"+ LAN"},
+				},
+				{
+					Name:   "Allow all from Internet",
+					Action: config.QuickMergeTop,
+					Value:  []string{"+ Internet"},
+				},
 			},
 		},
 		ValidationRegex: endpoints.ListEntryValidationRegex,
@@ -321,7 +340,7 @@ Important: DNS Requests are only matched against domain and filter list rules, a
 	if err != nil {
 		return err
 	}
-	cfgOptionServiceEndpoints = config.Concurrent.GetAsStringArray(CfgOptionServiceEndpointsKey, []string{})
+	cfgOptionServiceEndpoints = config.Concurrent.GetAsStringArray(CfgOptionServiceEndpointsKey, defaultIncomingRulesValue)
 	cfgStringArrayOptions[CfgOptionServiceEndpointsKey] = cfgOptionServiceEndpoints
 
 	filterListsHelp := strings.ReplaceAll(`Filter lists contain domains and IP addresses that are known to be used adversarial. The data is collected from many public sources and put into the following categories. In order to active a category, add it's "ID" to the list.
@@ -346,13 +365,13 @@ The lists are automatically updated every hour using incremental updates.
 `, `"`, "`")
 
 	// Filter list IDs
+	defaultFilterListsValue := []string{"TRAC", "MAL", "BAD"}
 	err = config.Register(&config.Option{
 		Name:         "Filter Lists",
 		Key:          CfgOptionFilterListsKey,
 		Description:  "Block connections that match enabled filter lists.",
-		Help:         filterListsHelp,
 		OptType:      config.OptTypeStringArray,
-		DefaultValue: []string{"TRAC", "MAL", "BAD"},
+		DefaultValue: defaultFilterListsValue,
 		Annotations: config.Annotations{
 			config.DisplayHintAnnotation:  "filter list",
 			config.DisplayOrderAnnotation: cfgOptionFilterListsOrder,
@@ -363,7 +382,7 @@ The lists are automatically updated every hour using incremental updates.
 	if err != nil {
 		return err
 	}
-	cfgOptionFilterLists = config.Concurrent.GetAsStringArray(CfgOptionFilterListsKey, []string{})
+	cfgOptionFilterLists = config.Concurrent.GetAsStringArray(CfgOptionFilterListsKey, defaultFilterListsValue)
 	cfgStringArrayOptions[CfgOptionFilterListsKey] = cfgOptionFilterLists
 
 	// Include CNAMEs

--- a/updates/helper/indexes.go
+++ b/updates/helper/indexes.go
@@ -33,6 +33,12 @@ func SetIndexes(registry *updater.ResourceRegistry, releaseChannel string, delet
 	// Reset indexes before adding them (again).
 	registry.ResetIndexes()
 
+	// Add the intel index first, in order to be able to override it with the
+	// other indexes when needed.
+	registry.AddIndex(updater.Index{
+		Path: "all/intel/intel.json",
+	})
+
 	// Always add the stable index as a base.
 	registry.AddIndex(updater.Index{
 		Path: ReleaseChannelStable + ".json",
@@ -84,13 +90,6 @@ func SetIndexes(registry *updater.ResourceRegistry, releaseChannel string, delet
 			warning = fmt.Errorf("failed to delete unused index %s: %w", indexPath, err)
 		}
 	}
-
-	// Add the intel index last, as it updates the fastest and should not be
-	// crippled by other faulty indexes. It can only specify versions for its
-	// scope anyway.
-	registry.AddIndex(updater.Index{
-		Path: "all/intel/intel.json",
-	})
 
 	// Set pre-release usage.
 	registry.SetUsePreReleases(usePreReleases)


### PR DESCRIPTION
- Improve read rights on log files
- Suppress error when stopping during filterlist update
- Deactivate IPv6 integrations when no IPv6 stack is detected
- Add geoip.IsInitialized to expose if the databases have been loaded
- Improve device location system with more safeguards
