### PR TITLE
Fix layered profile deadlocks

### DIFF
--- a/firewall/master.go
+++ b/firewall/master.go
@@ -270,10 +270,10 @@ func checkEndpointListsForSystemResolverDNSRequests(ctx context.Context, conn *n
 	var profileEndpoints endpoints.Endpoints
 	var optionKey string
 	if conn.Inbound {
-		profileEndpoints = p.LocalProfile().GetServiceEndpoints()
+		profileEndpoints = p.LocalProfileWithoutLocking().GetServiceEndpoints()
 		optionKey = profile.CfgOptionServiceEndpointsKey
 	} else {
-		profileEndpoints = p.LocalProfile().GetEndpoints()
+		profileEndpoints = p.LocalProfileWithoutLocking().GetEndpoints()
 		optionKey = profile.CfgOptionEndpointsKey
 	}
 

--- a/nameserver/nameserver.go
+++ b/nameserver/nameserver.go
@@ -231,7 +231,7 @@ func handleRequest(ctx context.Context, w dns.ResponseWriter, request *dns.Msg) 
 	// the resolving as it wishes.
 	if responder, ok := conn.Reason.Context.(nsutil.Responder); ok {
 		tracer.Infof("nameserver: handing over request for %s to special filter responder: %s", q.ID(), conn.Reason.Msg)
-		return reply(responder)
+		return reply(responder, conn)
 	}
 
 	// Check if there is a Verdict to act upon.

--- a/process/find.go
+++ b/process/find.go
@@ -81,7 +81,7 @@ func GetNetworkHost(ctx context.Context, remoteIP net.IP) (process *Process, err
 	}
 
 	// Assign profile to process.
-	networkHost.LocalProfileKey = networkHostProfile.Key()
+	networkHost.PrimaryProfileID = networkHostProfile.ScopedID()
 	networkHost.profile = networkHostProfile.LayeredProfile()
 
 	if networkHostProfile.Name == "" {

--- a/process/profile.go
+++ b/process/profile.go
@@ -89,7 +89,7 @@ func (p *Process) GetProfile(ctx context.Context) (changed bool, err error) {
 	}
 
 	// Assign profile to process.
-	p.LocalProfileKey = localProfile.Key()
+	p.PrimaryProfileID = localProfile.ScopedID()
 	p.profile = localProfile.LayeredProfile()
 
 	return true, nil

--- a/profile/profile-layered.go
+++ b/profile/profile-layered.go
@@ -168,6 +168,17 @@ func (lp *LayeredProfile) LocalProfile() *Profile {
 	return lp.localProfile
 }
 
+// LocalProfileWithoutLocking returns the local profile associated with this
+// layered profile, but without locking the layered profile.
+// This method my only be used when the caller already has a lock on the layered profile.
+func (lp *LayeredProfile) LocalProfileWithoutLocking() *Profile {
+	if lp == nil {
+		return nil
+	}
+
+	return lp.localProfile
+}
+
 // increaseRevisionCounter increases the revision counter and pushes the
 // layered profile to listeners.
 func (lp *LayeredProfile) increaseRevisionCounter(lock bool) (revisionCounter uint64) { //nolint:unparam // This is documentation.


### PR DESCRIPTION
- Mitigate double read locks on the layered profile
- Add metadata to special responder responses
