### PR TITLE
Update defaults

### DIFF
--- a/cmds/portmaster-core/main.go
+++ b/cmds/portmaster-core/main.go
@@ -4,6 +4,7 @@ import ( //nolint:gci,nolintlint
 	"os"
 
 	"github.com/safing/portbase/info"
+	"github.com/safing/portbase/log"
 	"github.com/safing/portbase/metrics"
 	"github.com/safing/portbase/run"
 	"github.com/safing/spn/conf"
@@ -20,6 +21,9 @@ import ( //nolint:gci,nolintlint
 func main() {
 	// set information
 	info.Set("Portmaster", "0.9.3", "AGPLv3", true)
+
+	// Set default log level.
+	log.SetLogLevel(log.WarningLevel)
 
 	// Configure metrics.
 	_ = metrics.SetNamespace("portmaster")

--- a/profile/config.go
+++ b/profile/config.go
@@ -346,7 +346,7 @@ Important: DNS Requests are only matched against domain and filter list rules, a
 	cfgStringArrayOptions[CfgOptionServiceEndpointsKey] = cfgOptionServiceEndpoints
 
 	// Filter list IDs
-	defaultFilterListsValue := []string{"TRAC", "MAL", "BAD"}
+	defaultFilterListsValue := []string{"TRAC", "MAL", "BAD", "UNBREAK"}
 	err = config.Register(&config.Option{
 		Name:         "Filter Lists",
 		Key:          CfgOptionFilterListsKey,


### PR DESCRIPTION
- Set default log level to warning for portmaster-core
- Enable filter list category Unbreak Popular Websites by default
