### PR TITLE
Allow single character tld (for internal usage)

### DIFF
--- a/network/netutils/dns.go
+++ b/network/netutils/dns.go
@@ -18,7 +18,7 @@ var (
 			`\.` + // ending with a dot
 			`)*` + // end subdomain group, allow any number of subdomains
 			`(xn--)?` + // TLD idn prefix
-			`[a-z0-9_-]{2,63}` + // TLD main chunk with at least two characters
+			`[a-z0-9_-]{1,63}` + // TLD main chunk with at least one character
 			`\.` + // ending with a dot
 			`$`, // match end
 	)


### PR DESCRIPTION
First at all many thanks for this great useful project.

Regarding this PR please consider it only as a suggestion, I can understand that loosening the constraints on the top level domain might not be something everyone wants, so I guess it might be better to make it configurable. On the other hand the option "Block Unofficial TLDs" should limit the TLDs anyway so maybe having the regular expression too restrictive might not be too important?

For me I unfortunately had to disable this to be able to use portmaster on a not conforming internal network. So if this could land in some way I'd be happy so I don't have to use a custom build! :pray: 

Best regards from Tirol!