### PR TITLE
Reconnect resolvers on SPN connect and other fixes

### DIFF
--- a/firewall/master.go
+++ b/firewall/master.go
@@ -116,7 +116,11 @@ func decideOnConnection(ctx context.Context, conn *network.Connection, pkt packe
 	case profile.DefaultActionPermit:
 		conn.Accept("allowed by default action", profile.CfgOptionDefaultActionKey)
 	case profile.DefaultActionAsk:
-		prompt(ctx, conn, pkt)
+		// Only prompt if there has not been a decision already.
+		// This prevents prompts from being created when re-evaluating connections.
+		if conn.Verdict.Firewall == network.VerdictUndecided {
+			prompt(ctx, conn)
+		}
 	default:
 		conn.Deny("blocked by default action", profile.CfgOptionDefaultActionKey)
 	}

--- a/firewall/prompt.go
+++ b/firewall/prompt.go
@@ -10,7 +10,6 @@ import (
 	"github.com/safing/portbase/notifications"
 	"github.com/safing/portmaster/intel"
 	"github.com/safing/portmaster/network"
-	"github.com/safing/portmaster/network/packet"
 	"github.com/safing/portmaster/profile"
 	"github.com/safing/portmaster/profile/endpoints"
 )
@@ -47,9 +46,9 @@ type promptProfile struct {
 	LinkedPath string
 }
 
-func prompt(ctx context.Context, conn *network.Connection, pkt packet.Packet) {
+func prompt(ctx context.Context, conn *network.Connection) {
 	// Create notification.
-	n := createPrompt(ctx, conn, pkt)
+	n := createPrompt(ctx, conn)
 	if n == nil {
 		// createPrompt returns nil when no further action should be taken.
 		return
@@ -81,11 +80,11 @@ func prompt(ctx context.Context, conn *network.Connection, pkt packet.Packet) {
 	}
 }
 
-// promptIDPrefix is an identifier for privacy filter prompts. This is also use
+// promptIDPrefix is an identifier for privacy filter prompts. This is also used
 // in the UI, so don't change!
 const promptIDPrefix = "filter:prompt"
 
-func createPrompt(ctx context.Context, conn *network.Connection, pkt packet.Packet) (n *notifications.Notification) {
+func createPrompt(ctx context.Context, conn *network.Connection) (n *notifications.Notification) {
 	expires := time.Now().Add(time.Duration(askTimeout()) * time.Second).Unix()
 
 	// Get local profile.
@@ -110,7 +109,7 @@ func createPrompt(ctx context.Context, conn *network.Connection, pkt packet.Pack
 			promptIDPrefix,
 			localProfile.ID,
 			conn.Inbound,
-			pkt.Info().RemoteIP(),
+			conn.Entity.IP,
 		)
 	default: // connection to domain
 		nID = fmt.Sprintf(

--- a/network/connection.go
+++ b/network/connection.go
@@ -119,7 +119,7 @@ type Connection struct { //nolint:maligned // TODO: fix alignment
 		// This is different from the Firewall verdict in order to guarantee proper
 		// transition between verdicts that need the connection to be re-established.
 		Active Verdict
-		// Firewall holsd the last (most recent) decision by the firewall.
+		// Firewall holds the last (most recent) decision by the firewall.
 		Firewall Verdict
 	}
 	// Reason holds information justifying the verdict, as well as additional

--- a/resolver/main.go
+++ b/resolver/main.go
@@ -67,7 +67,8 @@ func start() error {
 			return nil
 		},
 	); err != nil {
-		return err
+		// This module does not depend on the SPN/Captain module, and probably should not.
+		log.Warningf("resolvers: failed to register event hook for captain/spn-connect: %s", err)
 	}
 
 	// reload after config change

--- a/resolver/main.go
+++ b/resolver/main.go
@@ -57,6 +57,19 @@ func start() error {
 		return err
 	}
 
+	// Force resolvers to reconnect when SPN has connected.
+	if err := module.RegisterEventHook(
+		"captain",
+		"spn connect", // Defined by captain.SPNConnectedEvent
+		"force resolver reconnect",
+		func(ctx context.Context, _ any) error {
+			ForceResolverReconnect(ctx)
+			return nil
+		},
+	); err != nil {
+		return err
+	}
+
 	// reload after config change
 	prevNameservers := strings.Join(configuredNameServers(), " ")
 	err = module.RegisterEventHook(

--- a/resolver/resolver-env.go
+++ b/resolver/resolver-env.go
@@ -150,6 +150,8 @@ func (er *envResolverConn) IsFailing() bool {
 
 func (er *envResolverConn) ResetFailure() {}
 
+func (er *envResolverConn) ForceReconnect(_ context.Context) {}
+
 // QueryPortmasterEnv queries the environment resolver directly.
 func QueryPortmasterEnv(ctx context.Context, q *Query) (*RRCache, error) {
 	return envResolver.Conn.Query(ctx, q)

--- a/resolver/resolver-https.go
+++ b/resolver/resolver-https.go
@@ -8,15 +8,18 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/safing/portbase/log"
 )
 
 // HTTPSResolver is a resolver using just a single tcp connection with pipelining.
 type HTTPSResolver struct {
 	BasicResolverConn
-	Client *http.Client
+	client     *http.Client
+	clientLock sync.RWMutex
 }
 
 // HTTPSQuery holds the query information for a hTTPSResolverConn.
@@ -40,23 +43,13 @@ func (tq *HTTPSQuery) MakeCacheRecord(reply *dns.Msg, resolverInfo *ResolverInfo
 
 // NewHTTPSResolver returns a new HTTPSResolver.
 func NewHTTPSResolver(resolver *Resolver) *HTTPSResolver {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			ServerName: resolver.Info.Domain,
-			// TODO: use portbase rng
-		},
-		IdleConnTimeout: 3 * time.Minute,
-	}
-
-	client := &http.Client{Transport: tr}
 	newResolver := &HTTPSResolver{
 		BasicResolverConn: BasicResolverConn{
 			resolver: resolver,
 		},
-		Client: client,
 	}
 	newResolver.BasicResolverConn.init()
+	newResolver.refreshClient()
 	return newResolver
 }
 
@@ -86,7 +79,13 @@ func (hr *HTTPSResolver) Query(ctx context.Context, q *Query) (*RRCache, error) 
 		return nil, err
 	}
 
-	resp, err := hr.Client.Do(request)
+	// Lock client for usage.
+	hr.clientLock.RLock()
+	defer hr.clientLock.RUnlock()
+
+	// TODO: Check age of client and force a refresh similar to the TCP resolver.
+
+	resp, err := hr.client.Do(request)
 	if err != nil {
 		return nil, err
 	}
@@ -123,4 +122,36 @@ func (hr *HTTPSResolver) Query(ctx context.Context, q *Query) (*RRCache, error) 
 
 	// TODO: check if reply.Answer is valid
 	return newRecord, nil
+}
+
+// ForceReconnect forces the resolver to re-establish the connection to the server.
+func (hr *HTTPSResolver) ForceReconnect(ctx context.Context) {
+	hr.refreshClient()
+	log.Tracer(ctx).Tracef("resolver: created new HTTP client for %s", hr.resolver)
+}
+
+func (hr *HTTPSResolver) refreshClient() {
+	// Lock client for changing.
+	hr.clientLock.Lock()
+	defer hr.clientLock.Unlock()
+
+	// Attempt to close connection of previous client.
+	if hr.client != nil {
+		hr.client.CloseIdleConnections()
+	}
+
+	// Create new client.
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			ServerName: hr.resolver.Info.Domain,
+			// TODO: use portbase rng
+		},
+		IdleConnTimeout:     1 * time.Minute,
+		TLSHandshakeTimeout: defaultConnectTimeout,
+	}
+	hr.client = &http.Client{
+		Transport: tr,
+		Timeout:   maxRequestTimeout,
+	}
 }

--- a/resolver/resolver-https.go
+++ b/resolver/resolver-https.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+
 	"github.com/safing/portbase/log"
 )
 

--- a/resolver/resolver-mdns.go
+++ b/resolver/resolver-mdns.go
@@ -56,6 +56,8 @@ func (mrc *mDNSResolverConn) IsFailing() bool {
 
 func (mrc *mDNSResolverConn) ResetFailure() {}
 
+func (mrc *mDNSResolverConn) ForceReconnect(_ context.Context) {}
+
 type savedQuestion struct {
 	question dns.Question
 	expires  time.Time

--- a/resolver/resolver-plain.go
+++ b/resolver/resolver-plain.go
@@ -96,3 +96,7 @@ func (pr *PlainResolver) Query(ctx context.Context, q *Query) (*RRCache, error) 
 	// TODO: check if reply.Answer is valid
 	return newRecord, nil
 }
+
+// ForceReconnect forces the resolver to re-establish the connection to the server.
+// Does nothing for PlainResolver, as every request uses its own connection.
+func (pr *PlainResolver) ForceReconnect(_ context.Context) {}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -212,6 +212,7 @@ type ResolverConn interface { //nolint:golint // TODO
 	ReportFailure()
 	IsFailing() bool
 	ResetFailure()
+	ForceReconnect(ctx context.Context)
 }
 
 // BasicResolverConn implements ResolverConn for standard dns clients.

--- a/resolver/resolvers.go
+++ b/resolver/resolvers.go
@@ -479,6 +479,8 @@ func setScopedResolvers(resolvers []*Resolver) {
 	for _, resolver := range resolvers {
 		if resolver.Info.IPScope.IsLAN() {
 			localResolvers = append(localResolvers, resolver)
+		} else if _, err := netenv.GetLocalNetwork(resolver.Info.IP); err != nil {
+			localResolvers = append(localResolvers, resolver)
 		}
 
 		if resolver.Info.Source == ServerSourceOperatingSystem {

--- a/resolver/resolvers.go
+++ b/resolver/resolvers.go
@@ -570,3 +570,18 @@ func IsResolverAddress(ip net.IP, port uint16) bool {
 
 	return false
 }
+
+// ForceResolverReconnect forces all resolvers to reconnect.
+func ForceResolverReconnect(ctx context.Context) {
+	resolversLock.RLock()
+	defer resolversLock.RUnlock()
+
+	ctx, tracer := log.AddTracer(ctx)
+	defer tracer.Submit()
+
+	tracer.Trace("resolver: forcing all active resolvers to reconnect")
+	for _, r := range globalResolvers {
+		r.Conn.ForceReconnect(ctx)
+	}
+	tracer.Info("resolver: all active resolvers were forced to reconnect")
+}

--- a/resolver/scopes.go
+++ b/resolver/scopes.go
@@ -195,7 +195,6 @@ func GetResolversInScope(ctx context.Context, q *Query) (selected []*Resolver, p
 	if domainInScope(q.dotPrefixedFQDN, specialUseDomains) ||
 		domainInScope(q.dotPrefixedFQDN, specialServiceDomains) {
 		selected = addResolvers(ctx, q, selected, localResolvers)
-		selected = addResolvers(ctx, q, selected, systemResolvers)
 		return selected, "special", true
 	}
 


### PR DESCRIPTION
- Force resolvers to reconnect after connecting to SPN
- Add resolvers in device's network to LAN resolvers
- Send DNS queries to special domain only to local resolvers
- Disable prompting when re-evaluating connections
