### PR TITLE
Updating IP for Foundation for Applied Privacy

### DIFF
--- a/resolver/config.go
+++ b/resolver/config.go
@@ -151,7 +151,7 @@ The format is: "protocol://ip:port?parameter=value&parameter=value"
 					Name:   "Foundation for Applied Privacy",
 					Action: config.QuickReplace,
 					Value: []string{
-						"dot://dot1.applied-privacy.net?ip=94.130.106.88&name=AppliedPrivacy",
+						"dot://dot1.applied-privacy.net?ip=146.255.56.98&name=AppliedPrivacy",
 					},
 				},
 			},


### PR DESCRIPTION
Updating IP for Foundation for Applied Privacy per latest information on https://applied-privacy.net/services/dns/

Test results from dnsleaktest.com are below.

![image](https://user-images.githubusercontent.com/11684554/235682143-8cc38b61-6289-468d-9acc-668402081cc2.png)
