### PR TITLE
Attempt to add support for proxying updates and other HTTP requests - Request for Feedback - Do Not Merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,3 +117,7 @@ require (
 	modernc.org/memory v1.7.2 // indirect
 	modernc.org/sqlite v1.28.0 // indirect
 )
+
+replace (
+	github.com/safing/portbase => /home/user/GolandProjects/portbase/
+)

--- a/updates/config.go
+++ b/updates/config.go
@@ -106,6 +106,26 @@ func registerConfig() error {
 		return err
 	}
 
+	// Register a setting for the file path in the ui
+	err = config.Register(&config.Option{
+		Name:            "Proxy Address",
+		Key:             updateProxyURLKey,
+		Description:     "Specify a proxy url in the format protocol://ip_address:port to proxy update checks and downloads through",
+		OptType:         config.OptTypeString,
+		ExpertiseLevel:  config.ExpertiseLevelExpert,
+		ReleaseLevel:    config.ReleaseLevelStable,
+		DefaultValue:    "",
+		RequiresRestart: false,
+		Annotations: config.Annotations{
+			config.DisplayOrderAnnotation: config.DisplayHintOrdered,
+			config.CategoryAnnotation:     "Updates",
+			config.DisplayHintAnnotation:  config.DisplayHintAnnotation,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/updates/main.go
+++ b/updates/main.go
@@ -22,6 +22,7 @@ const (
 
 	enableSoftwareUpdatesKey = "core/automaticUpdates"
 	enableIntelUpdatesKey    = "core/automaticIntelUpdates"
+	updateProxyURLKey        = "core/updateProxy"
 
 	// ModuleName is the name of the update module
 	// and can be used when declaring module dependencies.
@@ -130,6 +131,7 @@ func start() error {
 		Verification:     helper.VerificationConfig,
 		DevMode:          devMode(),
 		Online:           true,
+		ProxyAddr:        updateProxyURLKey,
 	}
 	// Override values from flags.
 	if userAgentFromFlag != "" {


### PR DESCRIPTION
I'm attempting to add support for configuring an HTTP/SOCKS proxy for updates and other HTTP requests sent by portmaster. 

I have succeeded in getting this to work with a hard-coded string by modifying portbase in my fork here: https://github.com/Axionize/portbase. Nevertheless, making this a compile-time variable is obviously not ideal and I've been stuck trying to figure out how to add a config setting for this.

It appears that I can pass the proxy string from some kind of data registry in portmaster to portbase but I'm struggling to figure out how to expose this setting to the end user as an option in the Advanced Menu in the Updates drop-down.

I was planning to bang my head against the wall looking at how portmaster, porbase, and portmaster-ui fit together until it worked but figured I should just ask. How do I expose a setting in the webui and pass that data from the ui -> portmaster -> portbase?

Also, what's the workflow supposed to look like for putting these components together then testing and debugging all of them?