### PR TITLE
Improve self-check, port names, exe icons, online checks

### DIFF
--- a/compat/module.go
+++ b/compat/module.go
@@ -2,6 +2,7 @@ package compat
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/tevino/abool"
@@ -92,6 +93,9 @@ func selfcheckTaskFunc(ctx context.Context, task *modules.Task) error {
 	case err == nil:
 		// Successful.
 		tracer.Debugf("compat: self-check successful")
+	case errors.Is(err, errSelfcheckSkipped):
+		// Skipped.
+		tracer.Debugf("compat: %s", err)
 	case issue == nil:
 		// Internal error.
 		tracer.Warningf("compat: %s", err)

--- a/netenv/online-status.go
+++ b/netenv/online-status.go
@@ -435,7 +435,7 @@ func checkOnlineStatus(ctx context.Context) {
 
 	ipv4, ipv6, err := GetAssignedAddresses()
 	if err != nil {
-		log.Warningf("network: failed to get assigned network addresses: %s", err)
+		log.Warningf("netenv: failed to get assigned network addresses: %s", err)
 	} else {
 		var lan bool
 

--- a/netenv/online-status.go
+++ b/netenv/online-status.go
@@ -77,6 +77,7 @@ var (
 		"network-test.debian.org.",       // Debian
 		"204.pop-os.org.",                // Pop OS
 		"conncheck.opensuse.org.",        // OpenSUSE
+		"ping.archlinux.org",             // Arch
 		// There are probably a lot more domains for all the Linux Distro/DE Variants. Please raise issues and/or submit PRs!
 		// https://github.com/solus-project/budgie-desktop/issues/807
 		// https://www.lguruprasad.in/blog/2015/07/21/enabling-captive-portal-detection-in-gnome-3-14-on-debian-jessie/

--- a/network/reference/ports.go
+++ b/network/reference/ports.go
@@ -14,8 +14,8 @@ var (
 		25:  "SMTP",
 		43:  "WHOIS",
 		53:  "DNS",
-		67:  "DHCP-SERVER",
-		68:  "DHCP-CLIENT",
+		67:  "DHCP_SERVER",
+		68:  "DHCP_CLIENT",
 		69:  "TFTP",
 		80:  "HTTP",
 		110: "POP3",
@@ -27,10 +27,10 @@ var (
 		389: "LDAP",
 		443: "HTTPS",
 		445: "SMB",
-		587: "SMTP-ALT",
-		465: "SMTP-SSL",
-		993: "IMAP-SSL",
-		995: "POP3-SSL",
+		587: "SMTP_ALT",
+		465: "SMTP_SSL",
+		993: "IMAP_SSL",
+		995: "POP3_SSL",
 	}
 
 	portNumbers = map[string]uint16{
@@ -42,7 +42,9 @@ var (
 		"WHOIS":       43,
 		"DNS":         53,
 		"DHCP-SERVER": 67,
+		"DHCP_SERVER": 67,
 		"DHCP-CLIENT": 68,
+		"DHCP_CLIENT": 68,
 		"TFTP":        69,
 		"HTTP":        80,
 		"POP3":        110,
@@ -55,9 +57,13 @@ var (
 		"HTTPS":       443,
 		"SMB":         445,
 		"SMTP-ALT":    587,
+		"SMTP_ALT":    587,
 		"SMTP-SSL":    465,
+		"SMTP_SSL":    465,
 		"IMAP-SSL":    993,
+		"IMAP_SSL":    993,
 		"POP3-SSL":    995,
+		"POP3_SSL":    995,
 	}
 )
 

--- a/profile/binmeta/find_linux.go
+++ b/profile/binmeta/find_linux.go
@@ -77,7 +77,8 @@ func searchDirectory(directory string, binPath string) (iconPath string, err err
 		}
 		return "", fmt.Errorf("failed to read directory %s: %w", directory, err)
 	}
-	fmt.Println(directory)
+	// DEBUG:
+	// fmt.Println(directory)
 
 	var (
 		bestMatch            string

--- a/profile/binmeta/find_windows.go
+++ b/profile/binmeta/find_windows.go
@@ -63,29 +63,6 @@ func getIconAndNamefromRSS(ctx context.Context, binPath string) (png []byte, nam
 	// 	return true
 	// })
 
-	// Get first icon.
-	var (
-		icon    *winres.Icon
-		iconErr error
-	)
-	rss.WalkType(winres.RT_GROUP_ICON, func(resID winres.Identifier, langID uint16, _ []byte) bool {
-		icon, iconErr = rss.GetIconTranslation(resID, langID)
-		return iconErr != nil
-	})
-	if iconErr != nil {
-		return nil, "", fmt.Errorf("failed to get icon: %w", err)
-	}
-	// Convert icon.
-	icoBuf := &bytes.Buffer{}
-	err = icon.SaveICO(icoBuf)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to save ico: %w", err)
-	}
-	png, err = ConvertICOtoPNG(icoBuf.Bytes())
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to convert ico to png: %w", err)
-	}
-
 	// Get name from version record.
 	var (
 		versionInfo    *version.Info
@@ -110,6 +87,32 @@ func getIconAndNamefromRSS(ctx context.Context, binPath string) (png []byte, nam
 		return name == ""
 	})
 	name = cleanFileDescription(name)
+
+	// Get first icon.
+	var (
+		icon    *winres.Icon
+		iconErr error
+	)
+	rss.WalkType(winres.RT_GROUP_ICON, func(resID winres.Identifier, langID uint16, _ []byte) bool {
+		icon, iconErr = rss.GetIconTranslation(resID, langID)
+		return iconErr != nil
+	})
+	if iconErr != nil {
+		return nil, name, fmt.Errorf("failed to get icon: %w", err)
+	}
+	if icon == nil {
+		return nil, name, errors.New("no icon in resources")
+	}
+	// Convert icon, if it exists.
+	icoBuf := &bytes.Buffer{}
+	err = icon.SaveICO(icoBuf)
+	if err != nil {
+		return nil, name, fmt.Errorf("failed to save ico: %w", err)
+	}
+	png, err = ConvertICOtoPNG(icoBuf.Bytes())
+	if err != nil {
+		return nil, name, fmt.Errorf("failed to convert ico to png: %w", err)
+	}
 
 	return png, name, nil
 }


### PR DESCRIPTION
- Skip self-check if device is offline
- Add ping.archlinux.org to connectivity check domains
- Stop using dashes for port names, as they collide with port range dashes
- Improve finding windows exe icon
