### PR TITLE
Add PID in ETW DNS event in the integration dll

### DIFF
--- a/service/firewall/interception/dnsmonitor/etwlink_windows.go
+++ b/service/firewall/interception/dnsmonitor/etwlink_windows.go
@@ -22,8 +22,8 @@ type ETWSession struct {
 	state uintptr
 }
 
-// NewSession creates new ETW event listener and initilizes it. This is a low level interface, make sure to call DestorySession when you are done using it.
-func NewSession(etwInterface *integration.ETWFunctions, callback func(domain string, result string)) (*ETWSession, error) {
+// NewSession creates new ETW event listener and initializes it. This is a low level interface, make sure to call DestroySession when you are done using it.
+func NewSession(etwInterface *integration.ETWFunctions, callback func(domain string, pid uint32, result string)) (*ETWSession, error) {
 	if etwInterface == nil {
 		return nil, fmt.Errorf("etw interface was nil")
 	}
@@ -35,8 +35,8 @@ func NewSession(etwInterface *integration.ETWFunctions, callback func(domain str
 	_ = etwSession.i.StopOldSession()
 
 	// Initialize notification activated callback
-	win32Callback := windows.NewCallback(func(domain *uint16, result *uint16) uintptr {
-		callback(windows.UTF16PtrToString(domain), windows.UTF16PtrToString(result))
+	win32Callback := windows.NewCallback(func(domain *uint16, pid uint32, result *uint16) uintptr {
+		callback(windows.UTF16PtrToString(domain), pid, windows.UTF16PtrToString(result))
 		return 0
 	})
 	// The function only allocates memory it will not fail.
@@ -83,7 +83,7 @@ func (l *ETWSession) FlushTrace() error {
 	return l.i.FlushTrace(l.state)
 }
 
-// StopTrace stopes the trace. This will cause StartTrace to return.
+// StopTrace stops the trace. This will cause StartTrace to return.
 func (l *ETWSession) StopTrace() error {
 	return l.i.StopTrace(l.state)
 }

--- a/service/firewall/interception/dnsmonitor/eventlistener_linux.go
+++ b/service/firewall/interception/dnsmonitor/eventlistener_linux.go
@@ -141,5 +141,5 @@ func (l *Listener) processAnswer(domain string, queryResult *QueryResult) {
 		}
 	}
 
-	saveDomain(domain, ips, cnames)
+	saveDomain(domain, ips, cnames, resolver.IPInfoProfileScopeGlobal)
 }

--- a/service/firewall/interception/dnsmonitor/eventlistener_windows.go
+++ b/service/firewall/interception/dnsmonitor/eventlistener_windows.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/miekg/dns"
-	"github.com/safing/portmaster/base/log"
 	"github.com/safing/portmaster/service/mgr"
 	"github.com/safing/portmaster/service/process"
 	"github.com/safing/portmaster/service/resolver"

--- a/service/firewall/interception/dnsmonitor/eventlistener_windows.go
+++ b/service/firewall/interception/dnsmonitor/eventlistener_windows.go
@@ -94,8 +94,13 @@ func (l *Listener) processEvent(domain string, pid uint32, result string) {
 	}
 
 	profileScope := resolver.IPInfoProfileScopeGlobal
+	// Get the profile ID if the process can be found
 	if proc, err := process.GetOrFindProcess(context.Background(), int(pid)); err == nil {
-		profileScope = proc.Profile().LocalProfile().ID
+		if profile := proc.Profile(); profile != nil {
+			if localProfile := profile.LocalProfile(); localProfile != nil {
+				profileScope = localProfile.ID
+			}
+		}
 	}
 	cnames := make(map[string]string)
 	ips := []net.IP{}

--- a/service/firewall/interception/dnsmonitor/eventlistener_windows.go
+++ b/service/firewall/interception/dnsmonitor/eventlistener_windows.go
@@ -79,7 +79,7 @@ func (l *Listener) stop() error {
 	return nil
 }
 
-func (l *Listener) processEvent(domain string, result string) {
+func (l *Listener) processEvent(domain string, _pid uint32, result string) {
 	if processIfSelfCheckDomain(dns.Fqdn(domain)) {
 		// Not need to process result.
 		return

--- a/service/firewall/interception/dnsmonitor/module.go
+++ b/service/firewall/interception/dnsmonitor/module.go
@@ -61,7 +61,7 @@ func (dl *DNSMonitor) Flush() error {
 	return dl.listener.flush()
 }
 
-func saveDomain(domain string, ips []net.IP, cnames map[string]string) {
+func saveDomain(domain string, ips []net.IP, cnames map[string]string, profileScope string) {
 	fqdn := dns.Fqdn(domain)
 	// Create new record for this IP.
 	record := resolver.ResolvedDomain{
@@ -75,7 +75,7 @@ func saveDomain(domain string, ips []net.IP, cnames map[string]string) {
 	record.AddCNAMEs(cnames)
 
 	// Add to cache
-	saveIPsInCache(ips, resolver.IPInfoProfileScopeGlobal, record)
+	saveIPsInCache(ips, profileScope, record)
 }
 
 func New(instance instance) (*DNSMonitor, error) {

--- a/windows_core_dll/dllmain.cpp
+++ b/windows_core_dll/dllmain.cpp
@@ -22,7 +22,7 @@ static const GUID PORTMASTER_ETW_SESSION_GUID = {
 #define LOGSESSION_NAME L"PortmasterDNSEventListener"
 
 // Fuction type of the callback that will be called on each event.
-typedef uint64_t(*GoEventRecordCallback)(wchar_t* domain, wchar_t* result);
+typedef uint64_t(*GoEventRecordCallback)(wchar_t* domain, uint32_t pid, wchar_t* result);
 
 // Holds the state of the ETW Session.
 struct ETWSessionState {
@@ -41,7 +41,7 @@ static bool getPropertyValue(PEVENT_RECORD evt, LPWSTR prop, PBYTE* pData) {
     DataDescriptor.ArrayIndex = 0;
 
     DWORD PropertySize = 0;
-    // Check if the data is avaliable and what is the size of it.
+    // Check if the data is available and what is the size of it.
     DWORD status =
         TdhGetPropertySize(evt, 0, NULL, 1, &DataDescriptor, &PropertySize);
     if (ERROR_SUCCESS != status) {
@@ -79,7 +79,7 @@ static void WINAPI EventRecordCallback(PEVENT_RECORD eventRecord) {
     ETWSessionState* state = (ETWSessionState*)eventRecord->UserContext;
 
     if (resultValue != NULL && domainValue != NULL) {
-        state->callback((wchar_t*)domainValue, (wchar_t*)resultValue);
+        state->callback((wchar_t*)domainValue, eventRecord->EventHeader.ProcessId, (wchar_t*)resultValue);
     }
 
     free(resultValue);
@@ -160,7 +160,7 @@ extern "C" {
             EVENT_TRACE_CONTROL_STOP);
     }
 
-    // PM_ETWFlushTrace Closes the session and frees resourses.
+    // PM_ETWFlushTrace Closes the session and frees recourses.
     __declspec(dllexport) uint32_t PM_ETWDestroySession(ETWSessionState* state) {
         if (state == NULL) {
             return 1;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced callback functionality in the DNS monitor to include process ID information for improved event handling.
	- Updated domain saving mechanism to incorporate dynamic profile scope.
	- Improved retrieval of domain information related to connection's remote IP by isolating profile scope.

- **Bug Fixes**
	- Corrected minor typos in comments for better clarity and documentation accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->