### PR TITLE
[improvement] Small cache size

### DIFF
--- a/service/intel/filterlists/database.go
+++ b/service/intel/filterlists/database.go
@@ -50,7 +50,7 @@ var (
 var cache = database.NewInterface(&database.Options{
 	Local:     true,
 	Internal:  true,
-	CacheSize: 2 ^ 8,
+	CacheSize: 256,
 })
 
 // getFileFunc is the function used to get a file from


### PR DESCRIPTION
(2 ^ 8) = (2 XOR 8) = 10.
Was it intended to be 256?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the cache size configuration for improved database performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->