### PR TITLE
[fix] Panic while accessing SleepyTicker methods Stop()/SetSleep()

### DIFF
--- a/service/mgr/sleepyticker.go
+++ b/service/mgr/sleepyticker.go
@@ -4,7 +4,7 @@ import "time"
 
 // SleepyTicker is wrapper over time.Ticker that respects the sleep mode of the module.
 type SleepyTicker struct {
-	ticker         time.Ticker
+	ticker         *time.Ticker
 	normalDuration time.Duration
 	sleepDuration  time.Duration
 	sleepMode      bool
@@ -16,7 +16,7 @@ type SleepyTicker struct {
 // If sleepDuration is set to 0 ticker will not tick during sleep.
 func NewSleepyTicker(normalDuration time.Duration, sleepDuration time.Duration) *SleepyTicker {
 	st := &SleepyTicker{
-		ticker:         *time.NewTicker(normalDuration),
+		ticker:         time.NewTicker(normalDuration),
 		normalDuration: normalDuration,
 		sleepDuration:  sleepDuration,
 		sleepMode:      false,

--- a/service/mgr/sleepyticker_test.go
+++ b/service/mgr/sleepyticker_test.go
@@ -1,0 +1,57 @@
+package mgr
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSleepyTickerStop(t *testing.T) {
+	normalDuration := 100 * time.Millisecond
+	sleepDuration := 200 * time.Millisecond
+
+	st := NewSleepyTicker(normalDuration, sleepDuration)
+	st.Stop() // no panic expected here
+}
+
+func TestSleepyTicker(t *testing.T) {
+	normalDuration := 100 * time.Millisecond
+	sleepDuration := 200 * time.Millisecond
+
+	st := NewSleepyTicker(normalDuration, sleepDuration)
+
+	// Test normal mode
+	select {
+	case <-st.Wait():
+		// Expected tick
+	case <-time.After(normalDuration + 50*time.Millisecond):
+		t.Error("expected tick in normal mode")
+	}
+
+	// Test sleep mode
+	st.SetSleep(true)
+	select {
+	case <-st.Wait():
+		// Expected tick
+	case <-time.After(sleepDuration + 50*time.Millisecond):
+		t.Error("expected tick in sleep mode")
+	}
+
+	// Test sleep mode with sleepDuration == 0
+	st = NewSleepyTicker(normalDuration, 0)
+	st.SetSleep(true)
+	select {
+	case <-st.Wait():
+		t.Error("did not expect tick when sleepDuration is 0")
+	case <-time.After(normalDuration):
+		// Expected no tick
+	}
+
+	// Test stopping the ticker
+	st.Stop()
+	select {
+	case <-st.Wait():
+		t.Error("did not expect tick after stopping the ticker")
+	case <-time.After(normalDuration):
+		// Expected no tick
+	}
+}


### PR DESCRIPTION
The time.Ticker object was stored as a value type, but it is expected to be a pointer according to its implementation:
```
func (t *Ticker) Stop()
func (t *Ticker) Reset(d Duration)
```

This was leading to an application crash.

STR 1:
Run `portmaster-core` without privileged rights. It will not be able to start the kernel driver (Windows). During unloading of already initialized modules, the process crashes because of stopping SleepyTicker instances in workers of the "network" module.

STR 2:
Run tests from `service\mgr\sleepyticker_test.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced unit tests for the `SleepyTicker` functionality, validating its behavior in normal and sleep modes.
  
- **Bug Fixes**
	- Ensured safe stopping of the ticker without causing panic.

- **Refactor**
	- Updated the `ticker` field from a value type to a pointer type for improved memory management and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->