### PR TITLE
[fix] Logical mistake while determining local resolvers

### DIFF
--- a/service/resolver/resolvers.go
+++ b/service/resolver/resolvers.go
@@ -510,7 +510,7 @@ func setScopedResolvers(resolvers []*Resolver) {
 	for _, resolver := range resolvers {
 		if resolver.Info.IPScope.IsLAN() {
 			localResolvers = append(localResolvers, resolver)
-		} else if _, err := netenv.GetLocalNetwork(resolver.Info.IP); err != nil {
+		} else if net, _ := netenv.GetLocalNetwork(resolver.Info.IP); net != nil {
 			localResolvers = append(localResolvers, resolver)
 		}
 


### PR DESCRIPTION
It seems to be a logical mistake.

---
The previously created [PR](https://github.com/safing/portmaster/pull/1773) was mistakenly closed by me.
This is a duplicate PR.