### PR TITLE
Fix rust-base build

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -425,7 +425,7 @@ rust-base:
     DO rust+INIT --keep_fingerprints=true
 
     # For now we need tauri-cli 2.0.0 for bulding
-    DO rust+CARGO --args="install tauri-cli --version 2.1.0"
+    DO rust+CARGO --args="install tauri-cli --version 2.1.0 --locked"
 
     # Explicitly cache here.
     SAVE IMAGE --cache-hint


### PR DESCRIPTION
Sometimes rust attempts to upgrade crates. This stops it from doing that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `tauri-cli` installation process to use locked dependencies, ensuring consistent build reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->