### PR TITLE
Fix: updater restart action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ windows_core_dll/.vs/windows_core_dll
 #windows_core_dll
 windows_core_dll/x64/
 windows_core_dll/portmaster-core/x64/
+
+#Binaries used for installer gereneration for Windows
+desktop/tauri/src-tauri/binary/
+desktop/tauri/src-tauri/intel/

--- a/Earthfile
+++ b/Earthfile
@@ -603,6 +603,10 @@ installer-linux:
     SAVE ARTIFACT --if-exists --keep-ts "target/${target}/release/bundle/deb/*.deb" AS LOCAL "${outputDir}/${GO_ARCH_STRING}/"
     SAVE ARTIFACT --if-exists --keep-ts "target/${target}/release/bundle/rpm/*.rpm" AS LOCAL "${outputDir}/${GO_ARCH_STRING}/"
 
+all-artifacts:
+    BUILD +release-prep
+    BUILD +installer-linux
+
 kext-build:
     FROM ${rust_builder_image}
 

--- a/desktop/angular/package.json
+++ b/desktop/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portmaster",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "scripts": {
     "ng": "ng",
     "start": "npm install && npm run build-libs:dev && ng serve --proxy-config ./proxy.json",

--- a/desktop/tauri/src-tauri/Cargo.toml
+++ b/desktop/tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portmaster"
-version = "2.0.0"
+version = "2.0.1"
 description = "Portmaster UI"
 authors = ["Safing"]
 license = ""

--- a/service/config.go
+++ b/service/config.go
@@ -119,8 +119,8 @@ func MakeUpdateConfigs(svcCfg *ServiceConfig) (binaryUpdateConfig, intelUpdateCo
 			Directory:         svcCfg.BinDir,
 			DownloadDirectory: filepath.Join(svcCfg.DataDir, "download_binaries"),
 			PurgeDirectory:    filepath.Join(svcCfg.BinDir, "upgrade_obsolete_binaries"),
-			Ignore:            []string{"databases", "intel", "config.json"},
-			IndexURLs:         svcCfg.BinariesIndexURLs, // May be changed by config during instance startup.
+			Ignore:            []string{"uninstall.exe"}, // "databases", "intel" and "config.json" not needed here since they are not in the bin dir.
+			IndexURLs:         svcCfg.BinariesIndexURLs,  // May be changed by config during instance startup.
 			IndexFile:         "index.json",
 			Verify:            svcCfg.VerifyBinaryUpdates,
 			AutoCheck:         true, // May be changed by config during instance startup.
@@ -150,7 +150,7 @@ func MakeUpdateConfigs(svcCfg *ServiceConfig) (binaryUpdateConfig, intelUpdateCo
 			Directory:         svcCfg.BinDir,
 			DownloadDirectory: filepath.Join(svcCfg.DataDir, "download_binaries"),
 			PurgeDirectory:    filepath.Join(svcCfg.DataDir, "upgrade_obsolete_binaries"),
-			Ignore:            []string{"databases", "intel", "config.json"},
+			Ignore:            []string{},               // "databases", "intel" and "config.json" not needed here since they are not in the bin dir.
 			IndexURLs:         svcCfg.BinariesIndexURLs, // May be changed by config during instance startup.
 			IndexFile:         "index.json",
 			Verify:            svcCfg.VerifyBinaryUpdates,

--- a/service/updates/module.go
+++ b/service/updates/module.go
@@ -405,7 +405,7 @@ func (u *Updater) updateAndUpgrade(w *mgr.WorkerCtx, indexURLs []string, ignoreV
 						Type: notifications.ActionTypeWebhook,
 						Payload: notifications.ActionTypeWebhookPayload{
 							Method: "POST",
-							URL:    "updates/apply",
+							URL:    "core/restart",
 						},
 					},
 				},


### PR DESCRIPTION
1. Fixed the actual action performed by the "Restart" button after an update
2. Updated configuration to preserve uninstaller.exe on Windows
3. Removed unnecessary artifacts from the updated "Ignore files" configuration

@dhaavi There’s a topic to discuss:
Currently, the UI simply closes when the "Restart" action is triggered.
We need to consider how to properly restart it.