### PR TITLE
Only use stale dns cache entries when the query result was successful

### DIFF
--- a/service/resolver/resolve.go
+++ b/service/resolver/resolve.go
@@ -184,7 +184,7 @@ func Resolve(ctx context.Context, q *Query) (rrCache *RRCache, err error) {
 			case !rrCache.Expired():
 				// Return non-expired cached entry immediately.
 				return rrCache, nil
-			case useStaleCache():
+			case rrCache.RCode == dns.RcodeSuccess && useStaleCache():
 				// Return expired cache if we should use stale cache entries,
 				// but start an async query instead.
 				log.Tracer(ctx).Tracef(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache handling to ensure only expired entries with successful DNS responses are used when serving stale cache, preventing the use of expired cache entries with unsuccessful responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->