### PR TITLE
Fix/restrict UI process connections

### DIFF
--- a/desktop/tauri/src-tauri/src/window.rs
+++ b/desktop/tauri/src-tauri/src/window.rs
@@ -9,6 +9,8 @@ use crate::{portmaster::PortmasterExt, traymenu};
 const LIGHT_PM_ICON: &[u8] = include_bytes!("../../../../assets/data/icons/pm_light_512.png");
 const DARK_PM_ICON: &[u8] = include_bytes!("../../../../assets/data/icons/pm_dark_512.png");
 
+const CUSTOM_ENVVAR_FOR_WEBVIEW_PROCESS: &str = "PORTMASTER_UI_WEBVIEW_PROCESS";
+
 /// Either returns the existing "main" window or creates a new one.
 ///
 /// The window is not automatically shown (i.e it starts hidden).
@@ -24,6 +26,7 @@ pub fn create_main_window(app: &AppHandle) -> Result<WebviewWindow> {
     } else {
         debug!("[tauri] creating main window");
 
+        do_before_window_create(); // required operations before window creation
         let res = WebviewWindowBuilder::new(app, "main", WebviewUrl::App("index.html".into()))
             .title("Portmaster")
             .visible(false)
@@ -31,6 +34,7 @@ pub fn create_main_window(app: &AppHandle) -> Result<WebviewWindow> {
             .min_inner_size(800.0, 600.0)
             .theme(Some(Theme::Dark))
             .build();
+        do_after_window_create(); // required operations after window creation
 
         match res {
             Ok(win) => {
@@ -69,6 +73,8 @@ pub fn create_splash_window(app: &AppHandle) -> Result<WebviewWindow> {
         let _ = window.show();
         Ok(window)
     } else {
+
+        do_before_window_create(); // required operations before window creation
         let window = WebviewWindowBuilder::new(app, "splash", WebviewUrl::App("index.html".into()))
             .center()
             .closable(false)
@@ -78,6 +84,7 @@ pub fn create_splash_window(app: &AppHandle) -> Result<WebviewWindow> {
             .title("Portmaster")
             .inner_size(600.0, 250.0)
             .build()?;
+        do_after_window_create(); // required operations after window creation
         set_window_icon(&window);
 
         let _ = window.request_user_attention(Some(UserAttentionType::Informational));
@@ -117,6 +124,28 @@ pub fn set_window_icon(window: &WebviewWindow) {
         _ => window.set_icon(Image::from_bytes(LIGHT_PM_ICON).unwrap()),
     };
 }
+
+/// This function must be called before the window is created.
+/// 
+/// Temporarily sets the environment variable `PORTMASTER_WEBVIEW_UI_PROCESS` to "true".
+/// This ensures that any child process (i.e., the WebView process) spawned during window creation
+/// will inherit this environment variable. This allows portmaster-core to detect that the process
+/// is a child WebView of the main process.
+/// 
+/// IMPORTANT: After the window is created, you must call `do_after_window_create()` to remove
+/// the environment variable from the main process environment.
+pub fn do_before_window_create() {
+    std::env::set_var(CUSTOM_ENVVAR_FOR_WEBVIEW_PROCESS, "true");
+}
+
+/// This function must be called after the window is created.
+/// 
+/// Removes the `PORTMASTER_WEBVIEW_UI_PROCESS` environment variable from the main process.
+/// This ensures that only the child WebView process has the variable set, and the main process
+/// does not retain it.
+pub fn do_after_window_create() {
+    std::env::remove_var(CUSTOM_ENVVAR_FOR_WEBVIEW_PROCESS);
+} 
 
 /// Opens a window for the tauri application.
 ///

--- a/service/profile/special.go
+++ b/service/profile/special.go
@@ -237,14 +237,20 @@ func createSpecialProfile(profileID string, path string) *Profile {
 			Source:           SourceLocal,
 			PresentationPath: path,
 			Config: map[string]interface{}{
+				// Block all connections by default for the Portmaster UI profile,
+				// since the only required connections are to the Portmaster Core,
+				// which are fast-tracked.
+				//
+				// This ensures that any unexpected connections —
+				// possibly made by the internal WebView implementation —
+				// are blocked.
 				CfgOptionDefaultActionKey:      DefaultActionBlockValue,
-				CfgOptionBlockScopeInternetKey: false,
-				CfgOptionBlockScopeLANKey:      false,
-				CfgOptionBlockScopeLocalKey:    false,
-				CfgOptionBlockP2PKey:           false,
+				CfgOptionBlockScopeInternetKey: true,
+				CfgOptionBlockScopeLANKey:      true,
+				CfgOptionBlockScopeLocalKey:    true,
+				CfgOptionBlockP2PKey:           true,
 				CfgOptionBlockInboundKey:       true,
 				CfgOptionEndpointsKey: []string{
-					"+ Localhost",
 					"+ .safing.io",
 				},
 			},


### PR DESCRIPTION
Changes:

----

**1. The default configuration for the `Portmaster User Interface` profile was changed to block all connections.**
We need it to be sure that child WebView processes will not make any unexpected connections.

---- 
**2. Bugfix: `External processes wrongly classified as Portmaster UI on Windows`**
The `portmaster-core` uses specific logic to determine whether a process is related to the Portmaster UI binary.
If a process is a child of `C:\Program Files\Portmaster\portmaster.exe`, it is trusted as the Portmaster UI.
This allows `portmaster-core` to correctly recognize child WebView processes as part of the Portmaster UI.

Connections from the Portmaster UI are associated with a specific app profile: `Portmaster User Interface`.

**Problem:**
In some cases, the system browser may be launched from the Portmaster UI (e.g., when a user clicks a link in the UI).
Since the browser is started as a child of the Portmaster UI process, it is incorrectly trusted as part of the Portmaster UI.
As a result, all browser connections are treated as if they belong to the Portmaster User Interface profile, and the corresponding rules are applied.

**Steps to Reproduce (in PM version 2.0.14):**
1. Make sure no web browser processes are running.
2. Launch the Portmaster app.
3. Switch the UI to Developer Interface.
4. Click any link from the NEWS section (top-right corner of the app window).

**Observed Result:**
A new instance of the system's default web browser is started to open the link.
The Portmaster User Interface profile appears in the app list.
All web browser connections are listed under the Portmaster User Interface profile.
**Expected Result:**
The Portmaster User Interface profile should show only its own connections.
Web browser connections should be correctly associated with their own profiles (e.g., Google Chrome).

