### PR TITLE
[desktop] UI: Ctrl+/Crtl- shortcuts to Zoom-in/Zoom-out

### DIFF
--- a/desktop/tauri/src-tauri/capabilities/default.json
+++ b/desktop/tauri/src-tauri/capabilities/default.json
@@ -28,6 +28,7 @@
     "core:resources:default",
     "core:menu:default",
     "core:tray:default",
+    "core:webview:allow-set-webview-zoom",
     "shell:allow-open",
     "notification:default",
     "window-state:allow-save-window-state",

--- a/desktop/tauri/src-tauri/src/window.rs
+++ b/desktop/tauri/src-tauri/src/window.rs
@@ -35,6 +35,7 @@ pub fn create_main_window(app: &AppHandle) -> Result<WebviewWindow> {
             .visible(false)
             .inner_size(1200.0, 700.0)
             .min_inner_size(800.0, 600.0)
+            .zoom_hotkeys_enabled(true)
             .theme(Some(Theme::Dark))
             .on_page_load(|_window, _event| {
                 debug!("[tauri] main window page loaded: {}", _event.url());
@@ -104,6 +105,7 @@ pub fn create_splash_window(app: &AppHandle) -> Result<WebviewWindow> {
             .visible(true)
             .title("Portmaster")
             .inner_size(600.0, 250.0)
+            .zoom_hotkeys_enabled(true)
             .build()?;
         set_window_icon(&window);
 


### PR DESCRIPTION
https://github.com/safing/portmaster/issues/1961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled zoom keyboard shortcuts in the app’s windows to adjust interface scale (e.g., Ctrl/Cmd +, Ctrl/Cmd -, Ctrl/Cmd 0) for better readability. Applies to both the main window and the splash screen.

- Chores
  - Updated application permissions to allow webview zoom control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->