### PR TITLE
fix: Unnecessary filterlists database update on service start

### DIFF
--- a/service/intel/filterlists/database.go
+++ b/service/intel/filterlists/database.go
@@ -118,14 +118,6 @@ func processListFile(ctx context.Context, filter *scopedBloom, file *updates.Art
 		return
 	})
 
-	// Wait for the module initialization to complete to ensure the filter is fully loaded.
-	// This avoids prolonged locks during filter updates caused by concurrent database loading.
-	select {
-	case <-moduleInitDone:
-	case <-time.After(time.Second * 20):
-		log.Warning("intel/filterlists: timeout waiting for module initialization")
-	}
-
 	// Process each entry and send records to records channel.
 	startSafe(func() error {
 		defer close(records)


### PR DESCRIPTION
https://github.com/safing/portmaster/issues/1988

---
The filterlists database is often updated when the service starts, even if the latest version is already cached in the database. This does not affect PM’s functionality, but it unnecessarily consumes CPU resources.

**Technical explanation:**
This happens because the filterlists update check sometimes runs before the module is fully initialized.

**Steps to Reproduce:**
1. Start PM and ensure the filterlists are up to date.
2. Fully stop PM.
3. Start PM again.

**Observed result:**
PM reprocesses the filterlists cache database.

**Expected result:**
PM should update only when new data is available. Already processed data should not be reprocessed.