### PR TITLE
fix: SPN intel data is not applied in some cases

### DIFF
--- a/spn/captain/module.go
+++ b/spn/captain/module.go
@@ -135,8 +135,9 @@ func start() error {
 		crew.EnableConnecting(publicIdentity.Hub)
 	}
 
-	// Initialize intel.
-	module.mgr.Go("start", func(wc *mgr.WorkerCtx) error {
+	// Initialize SPN intel.
+	// Do this synchronously to ensure everything is up to date before
+	module.mgr.Do("start", func(wc *mgr.WorkerCtx) error {
 		if err := registerIntelUpdateHook(); err != nil {
 			return err
 		}

--- a/spn/captain/module.go
+++ b/spn/captain/module.go
@@ -137,7 +137,7 @@ func start() error {
 
 	// Initialize SPN intel.
 	// Do this synchronously to ensure everything is up to date before
-	module.mgr.Do("start", func(wc *mgr.WorkerCtx) error {
+	err = module.mgr.Do("start", func(wc *mgr.WorkerCtx) error {
 		if err := registerIntelUpdateHook(); err != nil {
 			return err
 		}
@@ -146,6 +146,9 @@ func start() error {
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 
 	// Subscribe to updates of cranes.
 	startDockHooks()

--- a/spn/navigator/intel.go
+++ b/spn/navigator/intel.go
@@ -67,13 +67,17 @@ func (m *Map) GetIntel() *hub.Intel {
 }
 
 func (m *Map) updateIntelStatuses(pin *Pin, trustNodes []string) {
-	// Reset all related states.
-	pin.removeStates(StateTrusted | StateUsageDiscouraged | StateUsageAsHomeDiscouraged | StateUsageAsDestinationDiscouraged)
+	// Reset all related states (StateSummaryStatusesAppliedFromIntel).
+	pin.stateIntelApplied.UnSet()
+	pin.removeStates(StateTrusted | StateUsageDiscouraged | StateUsageAsHomeDiscouraged | StateUsageAsDestinationDiscouraged) // same as: StateSummaryStatusesAppliedFromIntel
 
 	// Check if Intel data is loaded.
 	if m.intel == nil {
 		return
 	}
+
+	// Indicate that intel statuses have been applied to the pin
+	defer pin.stateIntelApplied.Set()
 
 	// Check Hub Intel
 	hubIntel, ok := m.intel.Hubs[pin.Hub.ID]

--- a/spn/navigator/options.go
+++ b/spn/navigator/options.go
@@ -246,6 +246,14 @@ func (o *HubOptions) Matcher(hubType HubType, hubIntel *hub.Intel) PinMatcher {
 			return false
 		}
 
+		// Check if all required states from intel were applied.
+		if regard.HasAnyOf(StateSummaryStatusesAppliedFromIntel) || disregard.HasAnyOf(StateSummaryStatusesAppliedFromIntel) {
+			if pin.stateIntelApplied.IsNotSet() {
+				log.Warningf("spn/navigator: pin %s skipped as intel statuses were not applied", pin.Hub.ID)
+				return false
+			}
+		}
+
 		// Check verified owners.
 		if len(o.RequireVerifiedOwners) > 0 {
 			// Check if Pin has a verified owner at all.

--- a/spn/navigator/pin.go
+++ b/spn/navigator/pin.go
@@ -26,6 +26,10 @@ type Pin struct { //nolint:maligned
 
 	// Hub Status
 	State PinState
+
+	// stateIntelApplied signifies that states from intel file were applied to the pin.
+	stateIntelApplied *abool.AtomicBool
+
 	// VerifiedOwner holds the name of the verified owner / operator of the Hub.
 	VerifiedOwner string
 	// HopDistance signifies the needed hops to reach this Hub.

--- a/spn/navigator/state.go
+++ b/spn/navigator/state.go
@@ -91,6 +91,12 @@ const (
 		StateOffline |
 		StateUsageDiscouraged |
 		StateIsHomeHub
+
+	// StateSummaryStatusesAppliedFromIntel summarizes all states that are applied from the intel file.
+	StateSummaryStatusesAppliedFromIntel = StateTrusted |
+		StateUsageDiscouraged |
+		StateUsageAsHomeDiscouraged |
+		StateUsageAsDestinationDiscouraged
 )
 
 var allStates = []PinState{

--- a/spn/navigator/update.go
+++ b/spn/navigator/update.go
@@ -168,9 +168,10 @@ func (m *Map) updateHub(h *hub.Hub, lockMap, lockHub bool) {
 		pin.Hub = h
 	} else {
 		pin = &Pin{
-			Hub:         h,
-			ConnectedTo: make(map[string]*Lane),
-			pushChanges: abool.New(),
+			Hub:               h,
+			ConnectedTo:       make(map[string]*Lane),
+			stateIntelApplied: abool.New(),
+			pushChanges:       abool.New(),
 		}
 		m.all[h.ID] = pin
 	}


### PR DESCRIPTION
- Prevent unintended use of SPN nodes when intel data is not yet applied
- Ensure intel data for the main SPN map is initialized before Portmaster starts an SPN connection

Related Issue Details:
In some situations, SPN intel data was not fully applied.
This lead to Portmaster making connections that don’t align with the intended intel preferences.

https://github.com/safing/portmaster/issues/1999