### PR TITLE
fix[desktop:Tauri]: block navigation to blank page

### DIFF
--- a/desktop/tauri/src-tauri/src/window.rs
+++ b/desktop/tauri/src-tauri/src/window.rs
@@ -42,6 +42,14 @@ pub fn create_main_window(app: &AppHandle) -> Result<WebviewWindow> {
                 debug!("[tauri] main window page loaded: {}", _event.url());
                 do_after_main_window_created(); // required operations after Main window creation
             })
+            .on_navigation(|url| {
+                debug!("[tauri] main window navigation event: {}", url);
+                if url.as_str() == "about:blank" {
+                    debug!("[tauri] blocking navigation to about:blank");
+                    return false;
+                }
+                return true;
+            })
             .build();
 
         match res {


### PR DESCRIPTION
https://github.com/safing/portmaster/issues/2023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a navigation guard in the main window to block invalid or blank destinations, reducing accidental blank screens and enhancing browsing safety within the app.
* **Bug Fixes**
  * Prevents rare navigations to a blank page when certain in-app links are triggered, improving reliability during link handling and window initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->