### PR TITLE
Fix/1949 linux recover iptables

### DIFF
--- a/cmds/portmaster-core/recover_linux.go
+++ b/cmds/portmaster-core/recover_linux.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -45,6 +46,8 @@ func recoverIPTables(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	chainNotExistPattern := regexp.MustCompile(`(?i)chain\s+\S+\s+does not exist`) // "Chain ... does not exist"
+
 	var filteredErrors *multierror.Error
 	for _, err := range mr.Errors {
 		// if we have a permission denied error, all errors will be the same
@@ -52,7 +55,9 @@ func recoverIPTables(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to cleanup iptables: %w", os.ErrPermission)
 		}
 
-		if !strings.Contains(err.Error(), "No such file or directory") {
+		if !strings.Contains(err.Error(), "No such file or directory") &&
+			!chainNotExistPattern.MatchString(err.Error()) {
+
 			filteredErrors = multierror.Append(filteredErrors, err)
 		}
 	}

--- a/packaging/linux/portmaster.service
+++ b/packaging/linux/portmaster.service
@@ -37,7 +37,7 @@ StateDirectory=portmaster
 # TODO(ppacher): add --disable-software-updates once it's merged and the release process changed.
 WorkingDirectory=/var/lib/portmaster
 ExecStart=/usr/lib/portmaster/portmaster-core --log-dir=/var/lib/portmaster/log -- $PORTMASTER_ARGS
-ExecStopPost=-/usr/lib/portmaster/portmaster-core -recover-iptables
+ExecStopPost=-/usr/lib/portmaster/portmaster-core --recover-iptables
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
https://github.com/safing/portmaster/issues/1949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Linux: Improved firewall recovery by ignoring non-actionable “chain does not exist” errors, reducing false error logs and avoiding unnecessary failures.
  - Systemd: Corrected stop post-action flag to ensure reliable iptables recovery during service shutdown. No change to permission-denied behavior.

- Chores
  - Minor service configuration adjustments to improve shutdown robustness and reduce noise during recovery operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->