### PR TITLE
fix: UI bug: when loading grouped connections from 'future'

### DIFF
--- a/desktop/angular/src/app/shared/netquery/netquery.component.ts
+++ b/desktop/angular/src/app/shared/netquery/netquery.component.ts
@@ -586,15 +586,17 @@ export class SfngNetqueryViewer implements OnInit, OnDestroy, AfterViewInit {
                   // the the correct resulsts here which depend on whether or not
                   // we're applying a group by.
                   let totalCount = 0;
-                  if (this.groupByKeys.length === 0) {
-                    totalCount = response.totalCount[0].totalCount;
-                  } else {
-                    totalCount = response.totalCount.length;
+                  if (response?.totalCount) {
+                    if (this.groupByKeys.length === 0 ) {
+                      totalCount = response.totalCount[0].totalCount;
+                    } else {
+                      totalCount = response.totalCount.length;
+                    }
                   }
 
                   return {
                     totalCount,
-                    totalConnCount: response.totalConnCount,
+                    totalConnCount: response?.totalConnCount || [],
                   }
                 })
               ),
@@ -633,7 +635,7 @@ export class SfngNetqueryViewer implements OnInit, OnDestroy, AfterViewInit {
         // reset the paginator with the new total result count and
         // open the first page.
         this.paginator.reset(result.response.totalCount);
-        this.totalConnCount = result.response.totalConnCount[0].totalConnCount;
+        this.totalConnCount = result.response?.totalConnCount[0]?.totalConnCount || 0;
         this.totalResultCount = result.response.totalCount;
 
         // update the current URL to include the new search


### PR DESCRIPTION
STR:

1. Network Activity View
2. Set "Search History" From/To dates in the future
3. Set "Group By" Domain 
 
Observed Result:
- Infinite “Loading connections…” status.
- The UI remains unresponsive to any changes in connection filters or reload actions.

https://github.com/safing/portmaster/issues/2041

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors when batch responses omit total counts, improving stability.
  * Displays 0 for total results and connections when data is unavailable, avoiding incorrect values.
  * Ensures paginator resets and chart-related totals update reliably even with partial responses.
  * Improves resilience of data handling for edge cases with missing fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->