### PR TITLE
Update log file path in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-bug.md
@@ -39,5 +39,5 @@ This is easiest to do in the preview mode.
 
 Additional logs can be found here:
 - Linux: `/var/lib/portmaster/log`
-- Windows: `%PROGRAMDATA%\Safing\Portmaster\logs`
+- Windows: `%PROGRAMDATA%\Portmaster\logs`
 -->

--- a/.github/ISSUE_TEMPLATE/report-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-bug.md
@@ -38,6 +38,6 @@ Paste debug information below:
 This is easiest to do in the preview mode.
 
 Additional logs can be found here:
-- Linux: `/opt/safing/portmaster/logs`
+- Linux: `/var/lib/portmaster/log`
 - Windows: `%PROGRAMDATA%\Safing\Portmaster\logs`
 -->

--- a/.github/ISSUE_TEMPLATE/report-compatibility.md
+++ b/.github/ISSUE_TEMPLATE/report-compatibility.md
@@ -31,5 +31,5 @@ This is easiest to do in the preview mode.
 
 If needed, additional logs can be found here:
 - Linux: `/var/lib/portmaster/log`
-- Windows: `%PROGRAMDATA%\Safing\Portmaster\logs`
+- Windows: `%PROGRAMDATA%\Portmaster\logs`
 -->

--- a/.github/ISSUE_TEMPLATE/report-compatibility.md
+++ b/.github/ISSUE_TEMPLATE/report-compatibility.md
@@ -30,6 +30,6 @@ Paste debug information below if reporting a problem:
 This is easiest to do in the preview mode.
 
 If needed, additional logs can be found here:
-- Linux: `/opt/safing/portmaster/logs`
+- Linux: `/var/lib/portmaster/log`
 - Windows: `%PROGRAMDATA%\Safing\Portmaster\logs`
 -->


### PR DESCRIPTION
I recently reported an issue and in the info text I was told to look for logs in `/opt/safing/portmaster/logs`. As I was then informed, this is no longer the case. I updated both issue templates to the new `/var/lib/portmaster/log/` path. Does Windows also need to be updated?