### PR TITLE
Packet injection and verdict setting fixes.

### DIFF
--- a/windows_kext/driver/src/packet_callouts.rs
+++ b/windows_kext/driver/src/packet_callouts.rs
@@ -274,6 +274,12 @@ fn clone_packet(
     };
 
     if let Some(data) = clone.get_data_mut() {
+        // Outbound packets intercepted at the IP layer may carry only a partial
+        // pseudo-header checksum because the TCP/IP stack relies on NIC hardware
+        // checksum offload to fill in the real value before transmission.
+        // When this clone is later re-injected via FwpsInjectNetwork*Async (on
+        // Accept/PermanentAccept verdict), it bypasses the NIC entirely, so offload
+        // never runs. We must compute the full software checksum here.
         recalc_header_checksums(data, ipv6);
     }
 

--- a/windows_kext/driver/src/packet_callouts.rs
+++ b/windows_kext/driver/src/packet_callouts.rs
@@ -12,7 +12,9 @@ use crate::connection::{
 use crate::connection_cache::ConnectionCache;
 use crate::connection_map::Key;
 use crate::device::{Device, Packet};
-use crate::packet_util::{get_key_from_nbl_v4, get_key_from_nbl_v6, Redirect};
+use crate::packet_util::{
+    get_key_from_nbl_v4, get_key_from_nbl_v6, recalc_header_checksums, Redirect,
+};
 
 // IP packet layers
 pub fn ip_packet_layer_outbound_v4(data: CalloutData) {
@@ -265,11 +267,16 @@ fn clone_packet(
     interface_index: u32,
     sub_interface_index: u32,
 ) -> Result<Packet, String> {
-    let clone = nbl.clone(&device.network_allocator)?;
+    let mut clone = nbl.clone(&device.network_allocator)?;
     let inbound = match direction {
         Direction::Outbound => false,
         Direction::Inbound => true,
     };
+
+    if let Some(data) = clone.get_data_mut() {
+        recalc_header_checksums(data, ipv6);
+    }
+
     Ok(Packet::PacketLayer(
         clone,
         InjectInfo {

--- a/windows_kext/wdk/src/filter_engine/callout_data.rs
+++ b/windows_kext/wdk/src/filter_engine/callout_data.rs
@@ -174,8 +174,6 @@ impl<'a> CalloutData<'a> {
 
     pub fn action_block(&mut self) {
         unsafe {
-            // Make the verdict immutable so the next layer can't change it
-            (*self.classify_out).clear_write_flag();
             (*self.classify_out).action_block();
             (*self.classify_out).clear_absorb_flag();
         }
@@ -190,8 +188,6 @@ impl<'a> CalloutData<'a> {
 
     pub fn block_and_absorb(&mut self) {
         unsafe {
-            // Make the verdict immutable so the next layer can't change it
-            (*self.classify_out).clear_write_flag();
             (*self.classify_out).action_block();
             (*self.classify_out).set_absorb();
         }

--- a/windows_kext/wdk/src/filter_engine/callout_data.rs
+++ b/windows_kext/wdk/src/filter_engine/callout_data.rs
@@ -174,6 +174,8 @@ impl<'a> CalloutData<'a> {
 
     pub fn action_block(&mut self) {
         unsafe {
+            // Make the verdict immutable so the next layer can't change it
+            (*self.classify_out).clear_write_flag();
             (*self.classify_out).action_block();
             (*self.classify_out).clear_absorb_flag();
         }
@@ -188,6 +190,8 @@ impl<'a> CalloutData<'a> {
 
     pub fn block_and_absorb(&mut self) {
         unsafe {
+            // Make the verdict immutable so the next layer can't change it
+            (*self.classify_out).clear_write_flag();
             (*self.classify_out).action_block();
             (*self.classify_out).set_absorb();
         }


### PR DESCRIPTION
61c3443deb4a83ca3dab2dac7fd1533456ab35b1: Makes the block and drop verdict immutable. This will make windows apply the verdict immediately and not let other layers in the chain override the verdict. Also makes the applying of the verdict immediate in the ALE layer. So applications will get permission denied when trying to create a connection instead of timeout after few seconds. 

04f8708448439fbef3f70a89b7d7714fdfb4375b: Fixes the packet injection in the packet callout. From what I remember this is only used in packet dns monitoring. Without recalculating the checksums the packet will just get dropped after injection by the network system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect checksum calculations for network packets in outbound traffic, ensuring proper packet validation for both IPv4 and IPv6 protocols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->