### PR TITLE
fix(wayland): [Workaround] disable WebGTK legacy rendering tech

### DIFF
--- a/desktop/tauri/src-tauri/tauri.conf.json5
+++ b/desktop/tauri/src-tauri/tauri.conf.json5
@@ -65,7 +65,6 @@
           "/usr/lib/portmaster/portmaster-core": "binary/portmaster-core",
           "/usr/lib/portmaster/portmaster.zip": "binary/portmaster.zip",
           "/usr/lib/portmaster/assets.zip": "binary/assets.zip",
-
           // Intel files
           "/var/lib/portmaster/intel/index.json": "intel/index.json",
           "/var/lib/portmaster/intel/base.dsdl": "intel/base.dsdl",
@@ -78,6 +77,9 @@
           "/var/lib/portmaster/intel/main-intel.yaml"   : "intel/main-intel.yaml",
           "/var/lib/portmaster/intel/notifications.yaml": "intel/notifications.yaml",
           "/var/lib/portmaster/intel/news.yaml"         : "intel/news.yaml",
+
+          // Scripts
+          "/usr/lib/portmaster/ui-wrapper": "../../../packaging/linux/ui-wrapper",
 
           // Shortcut
           "/etc/xdg/autostart/portmaster.desktop": "../../../packaging/linux/portmaster-autostart.desktop"

--- a/desktop/tauri/src-tauri/tauri.conf.json5
+++ b/desktop/tauri/src-tauri/tauri.conf.json5
@@ -115,6 +115,9 @@
           "/var/lib/portmaster/intel/notifications.yaml": "intel/notifications.yaml",
           "/var/lib/portmaster/intel/news.yaml"         : "intel/news.yaml",
 
+          // Scripts
+          "/usr/lib/portmaster/ui-wrapper": "../../../packaging/linux/ui-wrapper",
+
           // Shortcut
           "/etc/xdg/autostart/portmaster.desktop": "../../../packaging/linux/portmaster-autostart.desktop"
         },

--- a/packaging/linux/postinst
+++ b/packaging/linux/postinst
@@ -63,8 +63,9 @@ if command -V semanage >/dev/null 2>&1; then
 fi
 
 echo "[ ] Initializing binary files"
-mv /usr/bin/portmaster /usr/lib/portmaster/portmaster
-ln -s /usr/lib/portmaster/portmaster /usr/bin/portmaster 
+mv /usr/bin/portmaster /usr/lib/portmaster/portmaster-ui;
+chmod +x /usr/lib/portmaster/ui-wrapper;
+ln -sr /usr/lib/portmaster/ui-wrapper /usr/bin/portmaster;
 
 chmod +x /usr/lib/portmaster/portmaster-core
 

--- a/packaging/linux/postinst
+++ b/packaging/linux/postinst
@@ -66,14 +66,22 @@ echo "[ ] Initializing binary files"
 # Upon initial install, /usr/bin/portmaster gets foisted from archive unpacking.
 # Upon reconfiguration or reinstall, this state is undefined.
 cksum(){
-	# Checksum command nomrally dumps other info besides the actual checksum
+	# Checksum command normally dumps other info besides the actual checksum
 	# which clobbers shell comparisons. This is functional and POSIX compliant
 	command cksum "$@" | tr '[:space:]' "\n" | head -n 1;
 }
-if test "$(cksum /usr/bin/portmaster)" != "$(cksum /usr/lib/portmaster/ui-wrapper)"; then
+
+# protects from early installer termination via SIGKILL or SIGINT
+# leading to broken package state after dpkg-reconfigure or apt --fix-broken
+if test -f "/usr/bin/portmaster"; then
+	UI_CKSUM="$(cksum /usr/bin/portmaster)";
+	WRAP_CKSUM="$(cksum /usr/lib/portmaster/ui-wrapper)";
+
 	# When /usr/bin/portmaster is not the ui-wrapper, the state must be either
 	# a reinstall or upgrade and not reconfigure.
-	mv /usr/bin/portmaster /usr/lib/portmaster/portmaster-ui;
+	if test "$UI_CKSUM" != "$WRAP_CKSUM"; then 
+		mv /usr/bin/portmaster /usr/lib/portmaster/portmaster-ui;
+	fi;
 fi;
 chmod +x /usr/lib/portmaster/ui-wrapper;
 ln -srf /usr/lib/portmaster/ui-wrapper /usr/bin/portmaster;

--- a/packaging/linux/postinst
+++ b/packaging/linux/postinst
@@ -63,9 +63,20 @@ if command -V semanage >/dev/null 2>&1; then
 fi
 
 echo "[ ] Initializing binary files"
-mv /usr/bin/portmaster /usr/lib/portmaster/portmaster-ui;
+# Upon initial install, /usr/bin/portmaster gets foisted from archive unpacking.
+# Upon reconfiguration or reinstall, this state is undefined.
+cksum(){
+	# Checksum command nomrally dumps other info besides the actual checksum
+	# which clobbers shell comparisons. This is functional and POSIX compliant
+	command cksum "$@" | tr '[:space:]' "\n" | head -n 1;
+}
+if test "$(cksum /usr/bin/portmaster)" != "$(cksum /usr/lib/portmaster/ui-wrapper)"; then
+	# When /usr/bin/portmaster is not the ui-wrapper, the state must be either
+	# a reinstall or upgrade and not reconfigure.
+	mv /usr/bin/portmaster /usr/lib/portmaster/portmaster-ui;
+fi;
 chmod +x /usr/lib/portmaster/ui-wrapper;
-ln -sr /usr/lib/portmaster/ui-wrapper /usr/bin/portmaster;
+ln -srf /usr/lib/portmaster/ui-wrapper /usr/bin/portmaster;
 
 chmod +x /usr/lib/portmaster/portmaster-core
 

--- a/packaging/linux/postinst
+++ b/packaging/linux/postinst
@@ -65,23 +65,10 @@ fi
 echo "[ ] Initializing binary files"
 # Upon initial install, /usr/bin/portmaster gets foisted from archive unpacking.
 # Upon reconfiguration or reinstall, this state is undefined.
-cksum(){
-	# Checksum command normally dumps other info besides the actual checksum
-	# which clobbers shell comparisons. This is functional and POSIX compliant
-	command cksum "$@" | tr '[:space:]' "\n" | head -n 1;
-}
-
-# protects from early installer termination via SIGKILL or SIGINT
-# leading to broken package state after dpkg-reconfigure or apt --fix-broken
-if test -f "/usr/bin/portmaster"; then
-	UI_CKSUM="$(cksum /usr/bin/portmaster)";
-	WRAP_CKSUM="$(cksum /usr/lib/portmaster/ui-wrapper)";
-
+if ! test -L "/usr/bin/portmaster" || ! test -e "/usr/bin/portmaster"; then
 	# When /usr/bin/portmaster is not the ui-wrapper, the state must be either
 	# a reinstall or upgrade and not reconfigure.
-	if test "$UI_CKSUM" != "$WRAP_CKSUM"; then 
-		mv /usr/bin/portmaster /usr/lib/portmaster/portmaster-ui;
-	fi;
+	mv /usr/bin/portmaster /usr/lib/portmaster/portmaster-ui;
 fi;
 chmod +x /usr/lib/portmaster/ui-wrapper;
 ln -srf /usr/lib/portmaster/ui-wrapper /usr/bin/portmaster;

--- a/packaging/linux/ui-wrapper
+++ b/packaging/linux/ui-wrapper
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+
+# NOTE: This is a workaround for a WebkitGTK issue detailed in:
+#   -> https://github.com/flusterIO/fluster/issues/11
+if command -v "loginctl" 1>&2 2>/dev/null; then
+	case "$(loginctl -P Type show-session auto)" in
+		("x11")
+			exec /usr/lib/portmaster/portmaster-ui "$@"; 
+		;;
+		(*)
+			WEBKIT_DISABLE_DMABUF_RENDERER=1 \
+			WEBKIT_DISABLE_COMPOSITING_MODE=1 \
+			exec /usr/lib/portmaster/portmaster-ui "$@";
+		;;
+	esac;
+else
+	# Assume worst case scenario for compatability with Wayland in
+	# distributions that choose to avoid Systemd.
+	WEBKIT_DISABLE_DMABUF_RENDERER=1 \
+	WEBKIT_DISABLE_COMPOSITING_MODE=1 \
+	exec /usr/lib/portmaster/portmaster-ui "$@";
+fi;

--- a/packaging/linux/ui-wrapper
+++ b/packaging/linux/ui-wrapper
@@ -2,7 +2,7 @@
 
 # NOTE: This is a workaround for a WebkitGTK issue detailed in:
 #   -> https://github.com/flusterIO/fluster/issues/11
-if command -v "loginctl" 1>&2 2>/dev/null; then
+if command -v "loginctl" >/dev/null 2>&1; then
 	case "$(loginctl -P Type show-session auto)" in
 		("x11")
 			exec /usr/lib/portmaster/portmaster-ui "$@"; 
@@ -14,7 +14,7 @@ if command -v "loginctl" 1>&2 2>/dev/null; then
 		;;
 	esac;
 else
-	# Assume worst case scenario for compatability with Wayland in
+	# Assume worst case scenario for compatibility with Wayland in
 	# distributions that choose to avoid Systemd.
 	WEBKIT_DISABLE_DMABUF_RENDERER=1 \
 	WEBKIT_DISABLE_COMPOSITING_MODE=1 \


### PR DESCRIPTION
Disabled incompatible WebGTK rendering pipelines outside known X11 sessions. For a more detailed writeup on the issue see:
        https://github.com/flusterIO/fluster/issues/11

This project inherits the same bugs thanks to using Taury and depending on the system's webview (in this case WebGTK) implementation.

NOTE: This is untested code, I couldn't run a test build because your build system requires I be authenticated to Github for some reason! Also, it seemed like it scanned my LAN for SSH targets? I'm going to assume good faith but I know that's a bad idea. Really bums me out I can't validate this build for you before pushing it.

On my own rig I've done a temporary fix by wrapping the .desktop UI execution lines with a call to /usr/bin/env. But the below method is more maintainable in the event you encounter systems which run another system session like Ubuntu tried to implement at one point. Hopefully my POSIX shell script doesn't contain any errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Linux packaging updated so the app launcher now delegates to a new UI wrapper for improved startup behavior.
  * Installer now conditionally relocates the app binary, ensures the wrapper is executable, and updates the launcher symlink to use it.
  * Added a shared packaging asset for consistent installs across Debian and RPM.

* **Stability**
  * Launch routine auto-adjusts rendering and compositing for X11 vs Wayland to improve compatibility and reduce startup issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->