### PR TITLE
ci: Update github actions

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -29,15 +29,15 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
       with:
         node-version: 18
 
     - run: npm install
 
-    - uses: sibiraj-s/action-eslint@v3
+    - uses: sibiraj-s/action-eslint@bcf41bb9abce43cdbad51ab9b3da2eddaa17eab3 # v3
       with:
         annotations: true
         extensions: 'ts,html'
@@ -47,10 +47,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: earthly/actions-setup@v1
+    - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1
       with:
         version: v0.8.0
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,16 +33,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '^1.21'
         cache: false
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
       with:
         version: v1.64.6
         only-new-issues: true
@@ -55,10 +55,10 @@ jobs:
     name: Test & Build
     runs-on: ubuntu-latest
     steps:
-    - uses: earthly/actions-setup@v1
+    - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1
       with:
         version: v0.8.0
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1

--- a/.github/workflows/issues-first-greet.yml
+++ b/.github/workflows/issues-first-greet.yml
@@ -15,7 +15,7 @@ jobs:
   greet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v1
+      - uses: actions/first-interaction@2ec0f0fd78838633cd1c1342e4536d49ef72be54 # v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Respond to first time issue raisers.

--- a/.github/workflows/issues-label-actions.yml
+++ b/.github/workflows/issues-label-actions.yml
@@ -15,7 +15,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/label-actions@v3
+      - uses: dessant/label-actions@ade7bcd4c1b30de6ba8e556cc31301fd4f79ca65 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config-path: ".github/label-actions.yml"

--- a/.github/workflows/issues-stale.yml
+++ b/.github/workflows/issues-stale.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Increase max operations.

--- a/.github/workflows/kext.yml
+++ b/.github/workflows/kext.yml
@@ -24,10 +24,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: earthly/actions-setup@v1
+    - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1
       with:
         version: v0.8.0
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     name: Prep
     runs-on: ubuntu-latest
     steps:
-    - uses: earthly/actions-setup@v1
+    - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1
       with:
         version: v0.8.0
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -31,7 +31,7 @@ jobs:
       run: earthly --remote-cache=ghcr.io/safing/build-cache --push +release-prep
 
     - name: Upload Dist
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         path: ./dist/
         if-no-files-found: error
@@ -43,10 +43,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-prep
     steps:
-    - uses: earthly/actions-setup@v1
+    - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1
       with:
         version: v0.8.0
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -60,7 +60,7 @@ jobs:
       # --ci include --no-output flag
 
     - name: Upload Installers
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         path: ./dist/linux_amd64/
         if-no-files-found: error
@@ -73,10 +73,10 @@ jobs:
     needs: release-prep
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Download Dist
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         path: dist/
 
@@ -84,7 +84,7 @@ jobs:
       run: powershell -NoProfile -File ./packaging/windows/generate_windows_installers.ps1
 
     - name: Upload Installers
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         path: ./dist/windows_amd64/
         if-no-files-found: error

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -24,10 +24,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: earthly/actions-setup@v1
+    - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1
       with:
         version: v0.8.0
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -43,10 +43,10 @@ jobs:
     name: Linter
     runs-on: ubuntu-latest
     steps:
-    - uses: earthly/actions-setup@v1
+    - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1
       with:
         version: v0.8.0
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Log in to the Container registry
       uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1

--- a/.github/workflows/windows-dll.yml
+++ b/.github/workflows/windows-dll.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
     - name: Build DLL
       run: msbuild windows_core_dll\windows_core_dll.sln -t:rebuild -property:Configuration=Release
     - name: Verify DLL
@@ -40,7 +40,7 @@ jobs:
           exit 1
         }
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: portmaster-core-dll
         path: windows_core_dll/x64/Release/portmaster-core.dll


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions across CI/CD workflows to use pinned commit hashes instead of version tags, improving build reproducibility and stability across multiple jobs including linting, testing, and artifact publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->