### PR TITLE
feat(windows-kext): owner PID tracking, downstream filter bypass, and split-tunneling routing support

### DIFF
--- a/windows_kext/driver/src/ale_callouts.rs
+++ b/windows_kext/driver/src/ale_callouts.rs
@@ -183,7 +183,8 @@ fn ale_layer_auth(mut data: CalloutData, ale_data: AleLayerData) {
             Verdict::PermanentAccept
             | Verdict::Accept
             | Verdict::RedirectNameServer
-            | Verdict::RedirectTunnel => {
+            | Verdict::RedirectTunnel
+            | Verdict::RedirectSplitTunnel => {
                 // Continue to packet layer.
                 data.action_permit();
             }

--- a/windows_kext/driver/src/ale_callouts.rs
+++ b/windows_kext/driver/src/ale_callouts.rs
@@ -187,6 +187,13 @@ fn ale_layer_auth(mut data: CalloutData, ale_data: AleLayerData) {
             | Verdict::RedirectSplitTunnel => {
                 // Continue to packet layer.
                 data.action_permit();
+
+                if device.is_owner_pid(ale_data.process_id as u32) && matches!(ale_data.direction, Direction::Outbound) {
+                    // If this is Portmaster's own outbound connection, clear the write flag
+                    // to prevent subsequent filters in the chain from overriding the permit action.
+                    // This prevents other firewall applications from blocking Portmaster's own connections.
+                    data.clear_write_flag();
+                }
             }
             Verdict::PermanentBlock | Verdict::Undeterminable | Verdict::Failed => {
                 // Packet layer will not see this connection.

--- a/windows_kext/driver/src/connection.rs
+++ b/windows_kext/driver/src/connection.rs
@@ -11,8 +11,9 @@ use smoltcp::wire::{IpAddress, IpProtocol, Ipv4Address, Ipv6Address};
 
 use crate::connection_map::Key;
 
-pub static PM_DNS_PORT: u16 = 53;
-pub static PM_SPN_PORT: u16 = 717;
+pub static PM_DNS_PORT:       u16 = 53;
+pub static PM_SPN_PORT:       u16 = 717;
+pub static PM_SPLIT_TUN_PORT: u16 = 719;
 
 // Make sure this in sync with the Go version
 #[derive(Copy, Clone, FromPrimitive)]
@@ -27,9 +28,11 @@ pub enum Verdict {
     PermanentBlock     = 5,
     Drop               = 6,
     PermanentDrop      = 7,
-    RedirectNameServer = 8,
-    RedirectTunnel     = 9,
+    RedirectNameServer = 8,  // redirect to PM_DNS_PORT port
+    RedirectTunnel     = 9,  // redirect to PM_SPN_PORT port
     Failed             = 10,
+    RedirectSplitTunnel= 11, // redirect to PM_SPLIT_TUN_PORT port
+    // RedirectSplitTunnel must stay last: older Portmaster versions only know verdicts 0–10 and would never send this value.
 }
 
 impl Display for Verdict {
@@ -46,28 +49,9 @@ impl Display for Verdict {
             Verdict::PermanentDrop      => write!(f, "PermanentDrop"),
             Verdict::RedirectNameServer => write!(f, "RedirectNameServer"),
             Verdict::RedirectTunnel     => write!(f, "RedirectTunnel"),
+            Verdict::RedirectSplitTunnel=> write!(f, "RedirectSplitTunnel"),
             Verdict::Failed             => write!(f, "Failed"),
         }
-    }
-}
-
-#[allow(dead_code)]
-impl Verdict {
-    /// Returns true if the verdict is a redirect.
-    pub fn is_redirect(&self) -> bool {
-        matches!(self, Verdict::RedirectNameServer | Verdict::RedirectTunnel)
-    }
-
-    /// Returns true if the verdict is a permanent verdict.
-    pub fn is_permanent(&self) -> bool {
-        matches!(
-            self,
-            Verdict::PermanentAccept
-                | Verdict::PermanentBlock
-                | Verdict::PermanentDrop
-                | Verdict::RedirectNameServer
-                | Verdict::RedirectTunnel
-        )
     }
 }
 
@@ -122,6 +106,14 @@ pub trait Connection {
                 remote_address: self.get_remote_address(),
                 remote_port: self.get_remote_port(),
                 redirect_port: PM_SPN_PORT,
+                unify: true,
+                redirect_address,
+            }),
+            Verdict::RedirectSplitTunnel => Some(RedirectInfo {
+                local_address: self.get_local_address(),
+                remote_address: self.get_remote_address(),
+                remote_port: self.get_remote_port(),
+                redirect_port: PM_SPLIT_TUN_PORT,
                 unify: true,
                 redirect_address,
             }),
@@ -279,6 +271,12 @@ impl Connection for ConnectionV4 {
                 }
                 key.local_address.eq(&key.remote_address)
             }
+            Verdict::RedirectSplitTunnel => {
+                if key.remote_port != PM_SPLIT_TUN_PORT {
+                    return false;
+                }
+                key.local_address.eq(&key.remote_address)
+            }
             _ => false,
         }
     }
@@ -418,6 +416,12 @@ impl Connection for ConnectionV6 {
             }
             Verdict::RedirectTunnel => {
                 if key.remote_port != PM_SPN_PORT {
+                    return false;
+                }
+                key.local_address.eq(&key.remote_address)
+            }
+            Verdict::RedirectSplitTunnel => {
+                if key.remote_port != PM_SPLIT_TUN_PORT {
                     return false;
                 }
                 key.local_address.eq(&key.remote_address)

--- a/windows_kext/driver/src/device.rs
+++ b/windows_kext/driver/src/device.rs
@@ -162,7 +162,8 @@ impl Device {
                                 }
                             }
                             crate::connection::Verdict::RedirectNameServer
-                            | crate::connection::Verdict::RedirectTunnel => {
+                            | crate::connection::Verdict::RedirectTunnel
+                            | crate::connection::Verdict::RedirectSplitTunnel => {
                                 if let Some(redirect_info) = redirect_info {
                                     // Will not redirect packets from ALE layer
                                     if let Err(err) = packet.redirect(redirect_info) {

--- a/windows_kext/driver/src/device.rs
+++ b/windows_kext/driver/src/device.rs
@@ -29,9 +29,9 @@ pub enum Packet {
 pub struct Device {
     pub(crate) filter_engine: FilterEngine,
     pub(crate) read_leftover: ArrayHolder,
-    pub(crate) event_queue: IOQueue<Info>,
-    pub(crate) packet_cache: IdCache,
-    pub(crate) connection_cache: ConnectionCache,
+    pub(crate) event_queue: IOQueue<Info>,          // Queue for events to user-space
+    pub(crate) packet_cache: IdCache,               // Cache of pending packets waiting for verdict
+    pub(crate) connection_cache: ConnectionCache,   // Cache of connections and their verdicts
     pub(crate) injector: Injector,
     pub(crate) network_allocator: NetworkAllocator,
     pub(crate) bandwidth_stats: Bandwidth,

--- a/windows_kext/driver/src/device.rs
+++ b/windows_kext/driver/src/device.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use core::sync::atomic::{AtomicU32, Ordering};
 use num_traits::FromPrimitive;
 use protocol::{command::CommandType, info::Info};
 use smoltcp::wire::{IpAddress, IpProtocol, Ipv4Address, Ipv6Address};
@@ -34,6 +35,10 @@ pub struct Device {
     pub(crate) injector: Injector,
     pub(crate) network_allocator: NetworkAllocator,
     pub(crate) bandwidth_stats: Bandwidth,
+    /// PID of the user-space process that currently holds the device handle open.
+    /// Written once on IRP_MJ_CREATE, cleared on IRP_MJ_CLEANUP.
+    /// AtomicU32 gives lock-free reads in callouts with zero overhead.
+    pub(crate) owner_pid: AtomicU32,
 }
 
 impl Device {
@@ -57,7 +62,14 @@ impl Device {
             injector: Injector::new(),
             network_allocator: NetworkAllocator::new(),
             bandwidth_stats: Bandwidth::new(),
+            owner_pid: AtomicU32::new(0),
         })
+    }
+
+    /// Returns the PID of the process that currently has the device handle open, or 0 if none.
+    pub fn is_owner_pid(&self, pid: u32) -> bool {
+        let p = self.owner_pid.load(Ordering::Acquire);
+        p != 0 && p == pid
     }
 
     /// Cleanup is called just before drop.

--- a/windows_kext/driver/src/entry.rs
+++ b/windows_kext/driver/src/entry.rs
@@ -2,7 +2,7 @@ use crate::common::ControlCode;
 use crate::device;
 use alloc::boxed::Box;
 use num_traits::FromPrimitive;
-use wdk::irp_helpers::{DeviceControlRequest, ReadRequest, WriteRequest};
+use wdk::irp_helpers::{CleanupRequest, CreateRequest, DeviceControlRequest, ReadRequest, WriteRequest};
 use wdk::{err, info, interface};
 use windows_sys::Wdk::Foundation::{DEVICE_OBJECT, DRIVER_OBJECT, IRP};
 use windows_sys::Win32::Foundation::{NTSTATUS, STATUS_SUCCESS};
@@ -39,6 +39,8 @@ pub extern "system" fn driver_entry(
 
     // Set driver functions.
     driver.set_driver_unload(Some(driver_unload));
+    driver.set_create_fn(Some(driver_create));
+    driver.set_cleanup_fn(Some(driver_cleanup));
     driver.set_read_fn(Some(driver_read));
     driver.set_write_fn(Some(driver_write));
     driver.set_device_control_fn(Some(device_control));
@@ -66,6 +68,35 @@ unsafe extern "system" fn driver_unload(_object: *const DRIVER_OBJECT) {
             _ = Box::from_raw(DEVICE);
         }
     }
+}
+
+/// driver_create is triggered when user-space opens a handle to the device (CreateFile).
+unsafe extern "system" fn driver_create(
+    _device_object: *const DEVICE_OBJECT,
+    irp: *mut IRP,
+) -> NTSTATUS {
+    let mut create_request = CreateRequest::new(irp.as_mut().unwrap());
+    if let Some(device) = get_device() {
+        let pid = create_request.get_requestor_pid();
+        device.owner_pid.store(pid, core::sync::atomic::Ordering::Release);
+        info!("Device opened by PID {}", pid);
+    }
+    create_request.complete();
+    create_request.get_status()
+}
+
+/// driver_cleanup is triggered when user-space closes the last handle to the device.
+unsafe extern "system" fn driver_cleanup(
+    _device_object: *const DEVICE_OBJECT,
+    irp: *mut IRP,
+) -> NTSTATUS {
+    let mut cleanup_request = CleanupRequest::new(irp.as_mut().unwrap());
+    if let Some(device) = get_device() {
+        let old_pid = device.owner_pid.swap(0, core::sync::atomic::Ordering::Release);
+        info!("Device closed by PID {}", old_pid);
+    }
+    cleanup_request.complete();
+    cleanup_request.get_status()
 }
 
 // driver_read event triggered from user-space on file.Read.

--- a/windows_kext/driver/src/packet_callouts.rs
+++ b/windows_kext/driver/src/packet_callouts.rs
@@ -186,7 +186,7 @@ fn ip_packet_layer(
                         send_request_to_portmaster = false;
                         data.block_and_absorb();
                     }
-                    Verdict::RedirectNameServer | Verdict::RedirectTunnel => {
+                    Verdict::RedirectNameServer | Verdict::RedirectTunnel | Verdict::RedirectSplitTunnel => {
                         if let Some(redirect_info) = conn_info.redirect_info.take() {
                             match clone_packet(
                                 device,

--- a/windows_kext/test/BUILD_DEBUG.md
+++ b/windows_kext/test/BUILD_DEBUG.md
@@ -1,0 +1,215 @@
+# Building and Running Driver with Debug Logging
+
+## Driver Signing Requirement
+
+Windows requires **all kernel drivers to be signed**. Test signing provides a free alternative to expensive production code signing certificates for development and testing purposes.
+
+## Important: Debug Builds Are Disabled
+
+⚠️ **The driver cannot be compiled in debug mode.** The code contains a compile-time check (`compile_error!`) that prevents debug builds due to potential optimization-related issues and inconsistent compiler behavior between debug and release modes.
+
+However, you can still enable verbose logging in release builds by changing the log level.
+
+## Prerequisites
+
+Already documented in [main README](../README.md), but quick recap:
+
+1. **Visual Studio 2022** with C++ and Windows SDK
+2. **Windows Driver Kit (WDK)** installed
+3. **Rust toolchain** installed
+4. **Test signing enabled** (see below)
+
+## Step 1: Enable Test Signing (One-time Setup)
+
+⚠️ **SECURITY WARNING**: Test signing reduces system security by allowing any locally-generated test certificate to load kernel drivers. **Strongly recommended to use a VM or dedicated test machine**. See "Disabling Test Signing" section below to restore security when done testing.
+
+### Create Test Certificate
+
+Open **PowerShell as Administrator**:
+
+```powershell
+# Create a self-signed certificate for driver testing
+MakeCert -r -pe -ss PrivateCertStore -n "CN=DriverTestCert" DriverTestCert.cer
+
+# Install the certificate to Trusted Root
+CertMgr /add DriverTestCert.cer /s /r localMachine root
+
+# Install to Trusted Publishers (needed for driver installation)
+CertMgr /add DriverTestCert.cer /s /r localMachine trustedpublisher
+```
+
+### Enable Test Signing Mode
+
+```powershell
+# Enable test signing
+Bcdedit.exe -set TESTSIGNING ON
+
+# Restart required!
+Restart-Computer
+```
+
+After restart, you should see **"Test Mode"** watermark in the corner of your screen.
+
+### Verify Test Signing is Enabled
+
+```powershell
+bcdedit /enum | Select-String testsigning
+# Should show: testsigning Yes
+```
+
+## Step 2: Enable Debug Logging in Driver
+
+To see verbose logs from the driver, edit the log level before building.
+
+**Edit `driver/src/logger.rs`:**
+
+```rust
+// Change line 8 from:
+pub const LOG_LEVEL: u8 = Severity::Warning as u8;
+
+// To one of:
+pub const LOG_LEVEL: u8 = Severity::Debug as u8;   // Recommended for testing
+// pub const LOG_LEVEL: u8 = Severity::Info as u8;    // Less verbose
+// pub const LOG_LEVEL: u8 = Severity::Trace as u8;   // Most verbose
+```
+
+For testing, `Debug` level is recommended.
+
+## Step 3: Build Driver in Release Mode
+
+Navigate to the driver directory:
+
+```powershell
+cd D:\Projects\Portmaster\portmaster\windows_kext\driver
+
+# Build in release mode (only mode supported)
+cargo build --release --target x86_64-pc-windows-msvc
+
+# Output: driver/target/x86_64-pc-windows-msvc/release/driver.lib
+```
+
+**Note:** Debug builds (`cargo build` without `--release`) will fail with a compile error by design.
+
+## Step 4: Link the Driver
+
+Copy the `.lib` file to the root directory:
+
+```powershell
+cd D:\Projects\Portmaster\portmaster\windows_kext
+
+Copy-Item driver/target/x86_64-pc-windows-msvc/release/driver.lib . -Force
+```
+
+Run the linker script:
+
+```powershell
+.\link-dev.ps1
+```
+
+This creates `driver.sys` in the current directory.
+
+## Step 5: Sign the Driver
+
+## Step 5: Sign the Driver
+
+```powershell
+cd D:\Projects\Portmaster\portmaster\windows_kext
+
+# Sign the driver
+SignTool sign /v /s PrivateCertStore /n DriverTestCert driver.sys
+```
+
+Verify signature:
+
+```powershell
+SignTool verify /v /pa driver.sys
+```
+
+You should see: **"Successfully verified: driver.sys"**
+
+## Step 6: View Driver Logs
+
+### Ring Buffer Logs (Recommended)
+
+These logs come through the `GetLogs` command.
+
+### Kernel Debugger Output (Not Available in Release)
+
+The `wdk::dbg!()`, `wdk::info!()`, and `wdk::err!()` macros only work in debug builds, which are disabled for this driver. These would output to tools like DebugView via `DbgPrint`, but since debug builds are not allowed, this logging path is not available.
+
+**Use the ring buffer logs** (captured by `dbg!`, `info!`, `warn!`, `err!` macros) for all debugging.
+
+## Common Issues
+
+### "The hash for the file is not present in the specified catalog file"
+
+**Solution**: Your driver isn't signed or the certificate isn't trusted.
+```powershell
+# Re-sign the driver
+SignTool sign /v /s PrivateCertStore /n DriverTestCert driver.sys
+```
+
+### "Windows cannot verify the digital signature"
+
+**Solution**: Test signing not enabled or certificate not in Trusted Root.
+```powershell
+# Check test signing
+bcdedit /enum | Select-String testsigning
+
+# Reinstall certificate if needed
+CertMgr /add DriverTestCert.cer /s /r localMachine root
+```
+
+### "Service marked for deletion"
+
+**Solution**: Manually clean up:
+```powershell
+sc stop PortmasterKext
+sc delete PortmasterKext
+# Wait a few seconds
+# Then try starting again
+```
+
+### "Access is denied" when creating service
+
+**Solution**: Run as Administrator.
+
+### No debug output (`GetLogs` command)
+
+**Solution**: 
+1. Make sure you edited `driver/src/logger.rs` to set `LOG_LEVEL = Severity::Debug`
+2. Rebuild the driver in **release mode** (`cargo build --release`)
+3. The driver must be actively running and processing connections to generate logs
+4. Default log level (`Warning`) only shows errors, not normal operations
+
+## Quick Build & Test Cycle
+
+```powershell
+# 1. (Optional) Enable debug logging - edit driver/src/logger.rs first
+
+# 2. Build driver in release mode
+cd D:\Projects\Portmaster\portmaster\windows_kext\driver
+cargo build --release
+
+# 3. Link and sign
+cd ..
+Copy-Item driver/target/x86_64-pc-windows-msvc/release/driver.lib . -Force
+.\link-dev.ps1
+SignTool sign /v /s PrivateCertStore /n DriverTestCert driver.sys
+
+# 4. Test (in playground, as Administrator)
+```
+
+## Disabling Test Signing (When Done Testing)
+
+⚠️ **IMPORTANT**: When finished testing, disable test signing to restore system security.
+
+```powershell
+# Run as Administrator
+Bcdedit.exe -set TESTSIGNING OFF
+
+# Restart required for changes to take effect
+Restart-Computer
+```
+
+After restart, the "Test Mode" watermark will disappear and the system will no longer accept test-signed drivers. This restores normal kernel driver security enforcement.Production vs Test Signing

--- a/windows_kext/test/README.md
+++ b/windows_kext/test/README.md
@@ -1,0 +1,13 @@
+# Test Directory
+
+> ⚠️ **Notice**: This folder and its contents were primarily generated with the assistance of AI and may contain errors or inaccuracies. They are intended solely for local testing and development and must not be used in production.
+
+## Contents
+
+- `build_test.ps1` - Script to build the test-signed driver
+- `_out/` - Output directory for built test driver
+- `_testcert/` - Test certificates for driver signing
+
+## Purpose
+
+This directory contains tools and utilities for testing the Portmaster Windows kernel driver during development. These are developer tools only and are not part of the production build or release process.

--- a/windows_kext/test/build_test.ps1
+++ b/windows_kext/test/build_test.ps1
@@ -1,0 +1,145 @@
+﻿# Build and Sign Test Driver Script
+# Must be run from Developer PowerShell for Visual Studio
+
+$ErrorActionPreference = "Stop"
+
+# Get script directory and set paths
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$rootDir = Split-Path -Parent $scriptDir
+$driverDir = Join-Path $rootDir "driver"
+$certPath = Join-Path $rootDir "test\_testcert\DriverTestCert.cer"
+$outDir = Join-Path $scriptDir "_out"
+
+# Create output directory if it doesn't exist
+if (-not (Test-Path $outDir)) {
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+}
+
+Write-Host "=================================================" -ForegroundColor Cyan
+Write-Host "  Building and Signing Test Driver" -ForegroundColor Cyan
+Write-Host "=================================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Verify we are in the correct directory
+if (-not (Test-Path $driverDir)) {
+    Write-Host "ERROR: Driver directory not found at: $driverDir" -ForegroundColor Red
+    Write-Host "Please run this script from the windows_kext root directory or ensure paths are correct." -ForegroundColor Red
+    exit 1
+}
+
+# Verify certificate exists
+if (-not (Test-Path $certPath)) {
+    Write-Host "ERROR: Certificate not found at: $certPath" -ForegroundColor Red
+    Write-Host "Please create the test certificate first." -ForegroundColor Red
+    exit 1
+}
+
+#
+# Step 1: Build Driver in Release Mode
+#
+Write-Host "[1/3] Building driver in release mode..." -ForegroundColor Yellow
+Push-Location $driverDir
+try {
+    cargo build --release --target x86_64-pc-windows-msvc
+    
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: Cargo build failed with exit code $LASTEXITCODE" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+    
+    Write-Host "   Driver built successfully" -ForegroundColor Green
+} finally {
+    Pop-Location
+}
+
+#
+# Step 2: Link the Driver
+#
+Write-Host "[2/3] Linking driver..." -ForegroundColor Yellow
+Push-Location $outDir
+try {
+    # Copy the .lib file to output directory
+    $libSource = Join-Path $driverDir "target\x86_64-pc-windows-msvc\release\driver.lib"
+    $libDest = Join-Path $outDir "driver.lib"
+    
+    if (-not (Test-Path $libSource)) {
+        Write-Host "ERROR: Built driver.lib not found at: $libSource" -ForegroundColor Red
+        exit 1
+    }
+    
+    Copy-Item $libSource $libDest -Force
+    Write-Host "   Copied driver.lib" -ForegroundColor Green
+    
+    # Run linker script (from output directory so files are created here)
+    $linkScript = Join-Path $rootDir "link-dev.ps1"
+    if (-not (Test-Path $linkScript)) {
+        Write-Host "ERROR: link-dev.ps1 not found at: $linkScript" -ForegroundColor Red
+        exit 1
+    }
+    
+    & $linkScript
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: Linking failed with exit code $LASTEXITCODE" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+    
+    # Rename driver.sys to test name
+    $sysFile = Join-Path $outDir "driver.sys"
+    if (-not (Test-Path $sysFile)) {
+        Write-Host "ERROR: driver.sys was not created" -ForegroundColor Red
+        exit 1
+    }
+    
+    $testSysFile = Join-Path $outDir "PortmasterKext_test.sys"
+    Move-Item $sysFile $testSysFile -Force
+    
+    Write-Host "   Driver linked successfully (PortmasterKext_test.sys)" -ForegroundColor Green
+} finally {
+    Pop-Location
+}
+
+#
+# Step 3: Sign the Driver
+#
+Write-Host "[3/3] Signing driver..." -ForegroundColor Yellow
+Push-Location $outDir
+try {
+    $sysFile = Join-Path $outDir "PortmasterKext_test.sys"
+    
+    # Sign the driver
+    SignTool sign /v /fd SHA256 /s PrivateCertStore /n DriverTestCert $sysFile
+    
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "ERROR: Signing failed with exit code $LASTEXITCODE" -ForegroundColor Red
+        Write-Host "Make sure the certificate is installed in PrivateCertStore" -ForegroundColor Yellow
+        exit $LASTEXITCODE
+    }
+    
+    Write-Host "   Driver signed successfully" -ForegroundColor Green
+    
+    # Verify signature
+    Write-Host ""
+    Write-Host "Verifying signature..." -ForegroundColor Yellow
+    SignTool verify /v /pa $sysFile
+    
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "WARNING: Signature verification failed" -ForegroundColor Yellow
+    } else {
+        Write-Host "   Signature verified" -ForegroundColor Green
+    }
+} finally {
+    Pop-Location
+}
+
+Write-Host ""
+Write-Host "=================================================" -ForegroundColor Cyan
+Write-Host "  Build Complete!" -ForegroundColor Green
+Write-Host "=================================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Output directory: $outDir" -ForegroundColor White
+Write-Host "Driver file: PortmasterKext_test.sys" -ForegroundColor White
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor Yellow
+Write-Host "  1. Run playground as Administrator" -ForegroundColor White
+Write-Host "  2. Use start command to load the driver" -ForegroundColor White
+Write-Host ""

--- a/windows_kext/wdk/src/ffi.rs
+++ b/windows_kext/wdk/src/ffi.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use core::ffi::c_void;
 
 use windows_sys::{

--- a/windows_kext/wdk/src/ffi.rs
+++ b/windows_kext/wdk/src/ffi.rs
@@ -534,4 +534,8 @@ extern "C" {
     /// The KeQuerySystemTime routine obtains the current system time.
     /// System time is a count of 100-nanosecond intervals since January 1, 1601. System time is typically updated approximately every ten milliseconds. This value is computed for the GMT time zone.
     pub(crate) fn pm_QuerySystemTime() -> u64;
+
+    /// Returns the process identifier of the current process.
+    /// This is safe to call from IRP_MJ_CREATE handlers, which always execute in the context of the initiating user-space process.
+    pub(crate) fn PsGetCurrentProcessId() -> HANDLE;
 }

--- a/windows_kext/wdk/src/irp_helpers.rs
+++ b/windows_kext/wdk/src/irp_helpers.rs
@@ -9,6 +9,57 @@ use windows_sys::{
     },
 };
 
+/// Wraps an IRP_MJ_CREATE request (triggered when user-space opens the device handle).
+pub struct CreateRequest<'a> {
+    irp: &'a mut IRP,
+}
+
+impl CreateRequest<'_> {
+    pub fn new(irp: &mut IRP) -> CreateRequest<'_> {
+        CreateRequest { irp }
+    }
+
+    /// Returns the PID of the process that opened the device handle.
+    /// Safe to call here because IRP_MJ_CREATE always runs in the context
+    /// of the initiating process, never in an arbitrary system thread.
+    pub fn get_requestor_pid(&self) -> u32 {
+        unsafe { crate::ffi::PsGetCurrentProcessId() as u32 }
+    }
+
+    pub fn complete(&mut self) {
+        // FILE_OPENED (1): indicates the device was opened (not created/superseded).
+        const FILE_OPENED: usize = 1;
+        self.irp.IoStatus.Information = FILE_OPENED;
+        self.irp.IoStatus.Anonymous.Status = STATUS_SUCCESS;
+        unsafe { IofCompleteRequest(self.irp, IO_NO_INCREMENT as i8) };
+    }
+
+    pub fn get_status(&self) -> NTSTATUS {
+        unsafe { self.irp.IoStatus.Anonymous.Status }
+    }
+}
+
+/// Wraps an IRP_MJ_CLEANUP request (triggered when user-space closes the last handle).
+pub struct CleanupRequest<'a> {
+    irp: &'a mut IRP,
+}
+
+impl CleanupRequest<'_> {
+    pub fn new(irp: &mut IRP) -> CleanupRequest<'_> {
+        CleanupRequest { irp }
+    }
+
+    pub fn complete(&mut self) {
+        self.irp.IoStatus.Information = 0;
+        self.irp.IoStatus.Anonymous.Status = STATUS_SUCCESS;
+        unsafe { IofCompleteRequest(self.irp, IO_NO_INCREMENT as i8) };
+    }
+
+    pub fn get_status(&self) -> NTSTATUS {
+        unsafe { self.irp.IoStatus.Anonymous.Status }
+    }
+}
+
 pub struct ReadRequest<'a> {
     irp: &'a mut IRP,
     buffer: &'a mut [u8],

--- a/windows_kext/wdk/src/irp_helpers.rs
+++ b/windows_kext/wdk/src/irp_helpers.rs
@@ -16,7 +16,7 @@ pub struct ReadRequest<'a> {
 }
 
 impl ReadRequest<'_> {
-    pub fn new(irp: &mut IRP) -> ReadRequest {
+    pub fn new(irp: &mut IRP) -> ReadRequest<'_> {
         unsafe {
             let irp_sp = irp.Tail.Overlay.Anonymous2.Anonymous.CurrentStackLocation;
             let device_io = (*irp_sp).Parameters.Read;
@@ -79,7 +79,7 @@ pub struct WriteRequest<'a> {
 }
 
 impl WriteRequest<'_> {
-    pub fn new(irp: &mut IRP) -> WriteRequest {
+    pub fn new(irp: &mut IRP) -> WriteRequest<'_> {
         unsafe {
             let irp_sp = irp.Tail.Overlay.Anonymous2.Anonymous.CurrentStackLocation;
             let device_io = (*irp_sp).Parameters.Write;
@@ -131,7 +131,7 @@ struct DeviceIOControlParams {
 }
 
 impl DeviceControlRequest<'_> {
-    pub fn new(irp: &mut IRP) -> DeviceControlRequest {
+    pub fn new(irp: &mut IRP) -> DeviceControlRequest<'_> {
         unsafe {
             let irp_sp = irp.Tail.Overlay.Anonymous2.Anonymous.CurrentStackLocation;
             // Use the struct directly when replaced with proper version.

--- a/windows_kext/wdk/src/rw_spin_lock.rs
+++ b/windows_kext/wdk/src/rw_spin_lock.rs
@@ -26,7 +26,7 @@ impl RwSpinLock {
     ///
     /// This method blocks until a read lock can be acquired.
     /// Returns a `RwLockGuard` that represents the acquired read lock.
-    pub fn read_lock(&self) -> RwLockGuard {
+    pub fn read_lock(&self) -> RwLockGuard<'_> {
         let irq = unsafe { ExAcquireSpinLockShared(self.data.get()) };
         RwLockGuard {
             data: &self.data,
@@ -39,7 +39,7 @@ impl RwSpinLock {
     ///
     /// This method blocks until a write lock can be acquired.
     /// Returns a `RwLockGuard` that represents the acquired write lock.
-    pub fn write_lock(&self) -> RwLockGuard {
+    pub fn write_lock(&self) -> RwLockGuard<'_> {
         let irq = unsafe { ExAcquireSpinLockExclusive(self.data.get()) };
         RwLockGuard {
             data: &self.data,


### PR DESCRIPTION
## Summary

Windows kernel extension (kext) changes that prepare the driver for split-tunneling support:

1. **Owner PID tracking** — lets the driver identify Portmaster's own connections at callout time.
2. **Downstream filter bypass** — prevents other WFP filters from overriding a permit decision on Portmaster's own outbound connections.
3. **New `RedirectSplitTunnel` verdict** — adds the routing primitive needed to steer selected traffic to the split-tunnel proxy.

---

## Changes

### `feat(kext): track owner PID of connected user-space process`

- `Device` struct gains an `AtomicU32 owner_pid` field — written once on `IRP_MJ_CREATE`, cleared on `IRP_MJ_CLEANUP`. Lock-free reads are safe from callout context.
- `IRP_MJ_CREATE` / `IRP_MJ_CLEANUP` dispatch routines registered in `entry.rs` (`driver_create` / `driver_cleanup`).
- New `CreateRequest` and `CleanupRequest` IRP wrapper types added to `wdk/src/irp_helpers.rs`.
- `PsGetCurrentProcessId` FFI binding added to `wdk/src/ffi.rs`.

### `feat(kext): bypass downstream filters for Portmaster's own outbound connections`

- In the ALE callout, when the verdict is permit/redirect **and** the connection belongs to Portmaster itself (owner PID match + Outbound direction), the write-flag on the classify result is cleared. This prevents subsequent WFP filters in the sublayer chain from overriding the permit action.

### `feat(kext): add RedirectSplitTunnel verdict`

- Added `Verdict::RedirectSplitTunnel = 11` to the verdict enum in `connection.rs`, mapped to the new well-known port `PM_SPLIT_TUN_PORT = 719`.
- Wired the new verdict in the ALE callout, packet callout, and device layers alongside the existing redirect verdicts.
- IPv4 and IPv6 `is_own_packet()` extended with matching `RedirectSplitTunnel` arms.

> `RedirectSplitTunnel` is kept last in the enum so older Portmaster versions (verdicts 0–10 only) are not affected.

---

## Notes / Follow-ups

- The Go-side code that issues `RedirectSplitTunnel` verdicts is not yet merged — this PR only adds the kext-side handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added split tunnel redirection support, enabling new network traffic routing capability alongside existing tunnel and name server redirects.

* **Documentation**
  * Added comprehensive Windows kernel driver build and test documentation, including prerequisites, signing setup, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->