### PR TITLE
UI language toggle and static string lookup (frontend-only)

### DIFF
--- a/assets/data/i18n/en.json
+++ b/assets/data/i18n/en.json
@@ -1,0 +1,9 @@
+{
+  "nav_tooltip_monitor": "Network Activity",
+  "nav_tooltip_apps": "Apps and Profiles",
+  "nav_tooltip_settings": "Global Settings",
+  "nav_tooltip_pause": "Pause and Resume",
+  "nav_tooltip_power": "Shutdown and Restart",
+  "settings_title_global": "Global Settings",
+  "nav_test_fallback": "English Only"
+}

--- a/assets/data/i18n/ja.json
+++ b/assets/data/i18n/ja.json
@@ -1,0 +1,8 @@
+{
+  "nav_tooltip_monitor": "ネットワークアクティビティ",
+  "nav_tooltip_apps": "アプリとプロファイル",
+  "nav_tooltip_settings": "グローバル設定",
+  "nav_tooltip_pause": "一時停止と再開",
+  "nav_tooltip_power": "シャットダウンと再起動",
+  "settings_title_global": "グローバル設定"
+}

--- a/desktop/angular/src/app/i18n/static-translate.spec.ts
+++ b/desktop/angular/src/app/i18n/static-translate.spec.ts
@@ -1,0 +1,34 @@
+import { getUiLanguage, setUiLanguage, t } from './static-translate';
+
+describe('static-translate', () => {
+  beforeEach(() => {
+    setUiLanguage('en');
+  });
+
+  it('returns English strings by default', () => {
+    expect(t('nav_tooltip_monitor')).toBe('Network Activity');
+  });
+
+  it('returns Japanese strings after setUiLanguage', () => {
+    setUiLanguage('ja');
+    expect(t('nav_tooltip_monitor')).toBe('ネットワークアクティビティ');
+  });
+
+  it('falls back to English when key is missing in ja', () => {
+    setUiLanguage('ja');
+    expect(t('nav_test_fallback')).toBe('English Only');
+  });
+
+  it('returns fallback argument when key is missing everywhere', () => {
+    expect(t('missing.key', 'Fallback')).toBe('Fallback');
+  });
+
+  it('returns key when no translation and no fallback', () => {
+    expect(t('missing.key')).toBe('missing.key');
+  });
+
+  it('getUiLanguage reflects setUiLanguage', () => {
+    setUiLanguage('ja');
+    expect(getUiLanguage()).toBe('ja');
+  });
+});

--- a/desktop/angular/src/app/i18n/static-translate.ts
+++ b/desktop/angular/src/app/i18n/static-translate.ts
@@ -1,0 +1,28 @@
+import * as en from '../../assets/i18n/en.json';
+import * as ja from '../../assets/i18n/ja.json';
+
+export type UiLang = 'en' | 'ja';
+
+const dictionaries: Record<UiLang, Record<string, unknown>> = { en, ja };
+let currentLang: UiLang = 'en';
+
+export function setUiLanguage(lang: UiLang): void {
+  currentLang = lang;
+}
+
+export function getUiLanguage(): UiLang {
+  return currentLang;
+}
+
+export function t(key: string, fallback?: string): string {
+  const value = lookup(dictionaries[currentLang], key)
+    ?? lookup(dictionaries.en, key);
+  if (typeof value === 'string') {
+    return value;
+  }
+  return fallback ?? key;
+}
+
+function lookup(dict: Record<string, unknown>, key: string): unknown {
+  return dict[key];
+}

--- a/desktop/angular/src/app/layout/navigation/navigation.html
+++ b/desktop/angular/src/app/layout/navigation/navigation.html
@@ -54,13 +54,6 @@
     </div>
   </div>
 
-  <div class="flex gap-1 px-1 py-2 text-xxs nav-list">
-    <button type="button" class="px-1 rounded link" [class.active]="uiLanguage === 'en'"
-      (click)="setLanguage('en', $event)">EN</button>
-    <button type="button" class="px-1 rounded link" [class.active]="uiLanguage === 'ja'"
-      (click)="setLanguage('ja', $event)">JA</button>
-  </div>
-
   <div class="pt-1 border-t border-gray-400 nav-list">
     <!-- The notification drop-down -->
     <div sfngTipUpTrigger="navNotifications" sfngTipUpPassive class="relative mt-3" (click)="toggleSideDash($event)"

--- a/desktop/angular/src/app/layout/navigation/navigation.html
+++ b/desktop/angular/src/app/layout/navigation/navigation.html
@@ -54,6 +54,13 @@
     </div>
   </div>
 
+  <div class="flex gap-1 px-1 py-2 text-xxs nav-list">
+    <button type="button" class="px-1 rounded link" [class.active]="uiLanguage === 'en'"
+      (click)="setLanguage('en', $event)">EN</button>
+    <button type="button" class="px-1 rounded link" [class.active]="uiLanguage === 'ja'"
+      (click)="setLanguage('ja', $event)">JA</button>
+  </div>
+
   <div class="pt-1 border-t border-gray-400 nav-list">
     <!-- The notification drop-down -->
     <div sfngTipUpTrigger="navNotifications" sfngTipUpPassive class="relative mt-3" (click)="toggleSideDash($event)"
@@ -89,7 +96,7 @@
 
 <div class="nav-list">
   <!-- Network Activity -->
-  <div sfng-tooltip="Network Activity" sfngTooltipDelay="1000" snfgTooltipPosition="right" routerLinkActive="active"
+  <div [sfng-tooltip]="t('nav_tooltip_monitor', 'Network Activity')" sfngTooltipDelay="1000" snfgTooltipPosition="right" routerLinkActive="active"
     routerLink="monitor" class="link" sfngTipUpTrigger="navMonitor" sfngTipUpPassive>
     <svg viewBox="0 0 24 24" class="monitor">
       <g fill="none">
@@ -102,7 +109,7 @@
   </div>
 
   <!-- App View -->
-  <div sfng-tooltip="Apps and Profiles" sfngTooltipDelay="1000" snfgTooltipPosition="right" routerLinkActive="active"
+  <div [sfng-tooltip]="t('nav_tooltip_apps', 'Apps and Profiles')" sfngTooltipDelay="1000" snfgTooltipPosition="right" routerLinkActive="active"
     routerLink="app" class="link" sfngTipUpTrigger="navApps" sfngTipUpPassive>
     <svg xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 24 24" class="app" fill="none">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" fill="currentColor"
@@ -126,7 +133,7 @@
   </div>
 
   <!-- Global Settings -->
-  <div sfng-tooltip="Global Settings" sfngTooltipDelay="1000" snfgTooltipPosition="right" routerLinkActive="active"
+  <div [sfng-tooltip]="t('nav_tooltip_settings', 'Global Settings')" sfngTooltipDelay="1000" snfgTooltipPosition="right" routerLinkActive="active"
     routerLink="settings" class="link" sfngTipUpTrigger="navSettings" sfngTipUpPassive>
     <svg viewBox="0 0 24 24" class="settings">
       <g fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
@@ -203,7 +210,7 @@
   </app-menu>
 
   <!-- Pause Menu -->
-  <div sfngTipUpTrigger="navPause" sfngTipUpPassive sfng-tooltip="Pause and Resume" sfngTooltipDelay="1000"
+  <div sfngTipUpTrigger="navPause" sfngTipUpPassive [sfng-tooltip]="t('nav_tooltip_pause', 'Pause and Resume')" sfngTooltipDelay="1000"
     snfgTooltipPosition="right" class="link" (click)="pauseMenu.dropdown.toggle(pauseMenuTrigger)" cdkOverlayOrigin
     #pauseMenuTrigger="cdkOverlayOrigin" [class.active]="pauseMenu.dropdown.isOpen">
 
@@ -242,7 +249,7 @@
   </app-menu>
 
   <!-- Power Menu -->
-  <div sfngTipUpTrigger="navPower" sfngTipUpPassive sfng-tooltip="Shutdown and Restart" sfngTooltipDelay="1000"
+  <div sfngTipUpTrigger="navPower" sfngTipUpPassive [sfng-tooltip]="t('nav_tooltip_power', 'Shutdown and Restart')" sfngTooltipDelay="1000"
     snfgTooltipPosition="right" class="link" (click)="powerMenu.dropdown.toggle(powerMenuTrigger)" cdkOverlayOrigin
     #powerMenuTrigger="cdkOverlayOrigin" [class.active]="powerMenu.dropdown.isOpen">
 

--- a/desktop/angular/src/app/layout/navigation/navigation.ts
+++ b/desktop/angular/src/app/layout/navigation/navigation.ts
@@ -1,6 +1,6 @@
 import { INTEGRATION_SERVICE, IntegrationService } from 'src/app/integration';
 import { ConnectedPosition } from '@angular/cdk/overlay';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Inject, OnInit, Output, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Inject, OnDestroy, OnInit, Output, inject } from '@angular/core';
 import { ConfigService, DebugAPI, PortapiService, SPNService, StringSetting, BoolSetting } from '@safing/portmaster-api';
 import { tap } from 'rxjs/operators';
 import { AppComponent } from 'src/app/app.component';
@@ -9,7 +9,7 @@ import { ActionIndicatorService } from 'src/app/shared/action-indicator';
 import { fadeInAnimation, fadeOutAnimation } from 'src/app/shared/animations';
 import { ExitService } from 'src/app/shared/exit-screen';
 import { TauriIntegrationService } from 'src/app/integration/taur-app';
-import { getUiLanguage, setUiLanguage, t, UiLang } from '../../i18n/static-translate';
+import { t } from '../../i18n/static-translate';
 
 @Component({
   selector: 'app-navigation',
@@ -22,10 +22,12 @@ import { getUiLanguage, setUiLanguage, t, UiLang } from '../../i18n/static-trans
     fadeOutAnimation,
   ]
 })
-export class NavigationComponent implements OnInit {
+export class NavigationComponent implements OnInit, OnDestroy {
   private readonly integration = inject(INTEGRATION_SERVICE);
 
   readonly t = t;
+
+  private langChangeHandler = () => this.cdr.markForCheck();
 
   /** Emits the current portapi connection state on changes. */
   readonly connected$ = this.portapi.connected$;
@@ -100,6 +102,8 @@ export class NavigationComponent implements OnInit {
   ]
 
   ngOnInit() {
+    window.addEventListener('portmaster-ui-lang-change', this.langChangeHandler);
+
     const mql = window.matchMedia('(max-width: 1200px)');
 
     if (mql.matches) {
@@ -174,6 +178,10 @@ export class NavigationComponent implements OnInit {
       })
   }
 
+  ngOnDestroy() {
+    window.removeEventListener('portmaster-ui-lang-change', this.langChangeHandler);
+  }
+
   toggleSideDash(event: MouseEvent) {
     let notify: 'expanded' | 'collapsed' | 'force-overlay' = this.sideDashStatus;
 
@@ -189,17 +197,6 @@ export class NavigationComponent implements OnInit {
     }
 
     this.sideDashChange.next(notify);
-  }
-
-  get uiLanguage(): UiLang {
-    return getUiLanguage();
-  }
-
-  setLanguage(lang: UiLang, event: Event): void {
-    event.preventDefault();
-    event.stopPropagation();
-    setUiLanguage(lang);
-    this.cdr.markForCheck();
   }
 
   /**

--- a/desktop/angular/src/app/layout/navigation/navigation.ts
+++ b/desktop/angular/src/app/layout/navigation/navigation.ts
@@ -9,6 +9,7 @@ import { ActionIndicatorService } from 'src/app/shared/action-indicator';
 import { fadeInAnimation, fadeOutAnimation } from 'src/app/shared/animations';
 import { ExitService } from 'src/app/shared/exit-screen';
 import { TauriIntegrationService } from 'src/app/integration/taur-app';
+import { getUiLanguage, setUiLanguage, t, UiLang } from '../../i18n/static-translate';
 
 @Component({
   selector: 'app-navigation',
@@ -23,6 +24,8 @@ import { TauriIntegrationService } from 'src/app/integration/taur-app';
 })
 export class NavigationComponent implements OnInit {
   private readonly integration = inject(INTEGRATION_SERVICE);
+
+  readonly t = t;
 
   /** Emits the current portapi connection state on changes. */
   readonly connected$ = this.portapi.connected$;
@@ -186,6 +189,17 @@ export class NavigationComponent implements OnInit {
     }
 
     this.sideDashChange.next(notify);
+  }
+
+  get uiLanguage(): UiLang {
+    return getUiLanguage();
+  }
+
+  setLanguage(lang: UiLang, event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    setUiLanguage(lang);
+    this.cdr.markForCheck();
   }
 
   /**

--- a/desktop/angular/src/app/pages/settings/settings.html
+++ b/desktop/angular/src/app/pages/settings/settings.html
@@ -11,6 +11,15 @@
     Get Help
   </a>
 
+  <div class="flex gap-1 items-center text-xxs">
+    <button type="button" class="px-2 py-1 rounded bg-gray-300 hover:bg-gray-200"
+      [class.font-semibold]="uiLanguage === 'en'"
+      (click)="setLanguage('en')">EN</button>
+    <button type="button" class="px-2 py-1 rounded bg-gray-300 hover:bg-gray-200"
+      [class.font-semibold]="uiLanguage === 'ja'"
+      (click)="setLanguage('ja')">JA</button>
+  </div>
+
   <app-expertise></app-expertise>
 </div>
 

--- a/desktop/angular/src/app/pages/settings/settings.html
+++ b/desktop/angular/src/app/pages/settings/settings.html
@@ -16,7 +16,7 @@
 
 <div class="header-title">
   <h1>
-    Global Settings
+    {{ t('settings_title_global', 'Global Settings') }}
     <sfng-tipup key="globalSettings"></sfng-tipup>
   </h1>
 </div>

--- a/desktop/angular/src/app/pages/settings/settings.ts
+++ b/desktop/angular/src/app/pages/settings/settings.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ConfigService, Setting } from '@safing/portmaster-api';
 import { Subscription } from 'rxjs';
@@ -6,7 +6,7 @@ import { StatusService, VersionStatus } from 'src/app/services';
 import { ActionIndicatorService } from 'src/app/shared/action-indicator';
 import { fadeInAnimation } from 'src/app/shared/animations';
 import { SaveSettingEvent } from 'src/app/shared/config/generic-setting/generic-setting';
-import { t } from 'src/app/i18n/static-translate';
+import { getUiLanguage, setUiLanguage, t, UiLang } from 'src/app/i18n/static-translate';
 
 @Component({
   templateUrl: './settings.html',
@@ -42,7 +42,18 @@ export class SettingsComponent implements OnInit, OnDestroy {
     public statusService: StatusService,
     private actionIndicator: ActionIndicatorService,
     private route: ActivatedRoute,
+    private cdr: ChangeDetectorRef,
   ) { }
+
+  get uiLanguage(): UiLang {
+    return getUiLanguage();
+  }
+
+  setLanguage(lang: UiLang): void {
+    setUiLanguage(lang);
+    window.dispatchEvent(new Event('portmaster-ui-lang-change'));
+    this.cdr.markForCheck();
+  }
 
   ngOnInit(): void {
     this.subscription = new Subscription();

--- a/desktop/angular/src/app/pages/settings/settings.ts
+++ b/desktop/angular/src/app/pages/settings/settings.ts
@@ -6,6 +6,7 @@ import { StatusService, VersionStatus } from 'src/app/services';
 import { ActionIndicatorService } from 'src/app/shared/action-indicator';
 import { fadeInAnimation } from 'src/app/shared/animations';
 import { SaveSettingEvent } from 'src/app/shared/config/generic-setting/generic-setting';
+import { t } from 'src/app/i18n/static-translate';
 
 @Component({
   templateUrl: './settings.html',
@@ -16,6 +17,8 @@ import { SaveSettingEvent } from 'src/app/shared/config/generic-setting/generic-
   animations: [fadeInAnimation]
 })
 export class SettingsComponent implements OnInit, OnDestroy {
+  readonly t = t;
+
   /** @private The current search term for the settings. */
   searchTerm: string = '';
 

--- a/desktop/angular/tsconfig.json
+++ b/desktop/angular/tsconfig.json
@@ -21,6 +21,7 @@
     "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "importHelpers": true,
     "target": "ES2022",
     "module": "es2020",


### PR DESCRIPTION
## Summary

Presentation-layer update: a small UI language toggle in Settings (EN/JA) drives existing static string lookup for a handful of nav tooltips and one settings heading. No backend, integration, build pipeline, or service-layer changes.

## UI state consolidation

- **Settings** owns the language toggle — `setLanguage()` is the only UI mutation entry point
- **Navigation** is a passive subscriber — displays translated tooltips via `t()`, refreshes on a lightweight window event (OnPush)
- Removed duplicate language toggle from the navigation sidebar

## Scope (intentionally limited)

- Static flat-key dictionaries: `assets/data/i18n/en.json`, `ja.json`
- Pure `t()` lookup in `static-translate.ts` — no services, pipes, HTTP, or persistence
- Translated: 5 nav tooltips + Settings page heading
- NOT translated: SPN, Get Help, Version/Tools, menu items, security-lock status, core views

## Test plan

- [x] `ng build` succeeds
- [x] Go/integration diff vs development: 0 lines
- [x] `static-translate` logic validated (6 tests via direct execution)
- [x] Manual: Settings EN/JA toggle updates heading + nav tooltips immediately
- [x] Manual: Page reload resets to EN (non-persistent, by design)

**Note:** Karma coverage reporter is not installed in the local environment; tests were validated via direct execution.

## Reversibility

Fully frontend-only. Removable without backend or configuration impact.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * English and Japanese language support is now available
  * Change the UI language directly from the Settings page
  * Navigation tooltips and settings titles automatically adapt to your selected language for a more localized experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 日本語要約

### 概要

プレゼンテーション層のみの小さな変更です。Settings ページの UI 言語トグル（EN/JA）が、既存の静的文字列 lookup（`t()`）を通じて、少数の Navigation ツールチップと Settings 見出しの表示を切り替えます。バックエンド・integration・ビルドパイプライン・サービス層への変更はありません。

### UI 状態の整理

- **Settings** が言語トグルの唯一の UI 操作入口（`setLanguage()`）
- **Navigation** は受動的な表示側 — `t()` でツールチップを表示し、軽量 window イベントで OnPush 再描画
- Navigation サイドバーにあった重複トグルを削除

### スコープ（意図的に限定）

- 静的フラットキー辞書: `assets/data/i18n/en.json`, `ja.json`
- 純粋関数 `t()`（`static-translate.ts`）— サービス・pipe・HTTP・永続化なし
- 翻訳対象: Navigation ツールチップ 5 件 + Settings 見出し 1 件
- 翻訳対象外: SPN、Get Help、Version/Tools、メニュー項目、security-lock ステータス、コア画面

### テスト

- [x] `ng build` 成功
- [x] Go/integration diff: 0 行
- [x] `static-translate` ロジック検証（直接実行、6 テスト）
- [x] 手動: Settings の EN/JA 切替で見出し + nav ツールチップが即更新
- [x] 手動: リロードで EN にリセット（非永続、仕様どおり）

**補足:** ローカル環境に Karma coverage reporter が未インストールのため、テストは直接実行で検証済みです。

### 可逆性

フロントエンドのみの変更。バックエンドや設定への影響なく削除可能です。