### PR TITLE
Repair corrupted resource updates at current version

### DIFF
--- a/service/intel/filterlists/updater.go
+++ b/service/intel/filterlists/updater.go
@@ -51,6 +51,8 @@ func tryListUpdate(ctx context.Context) error {
 		return err
 	}
 
+	// Clear the failure state on any successful update check.
+	module.states.Remove(filterlistsUpdateFailed)
 	return nil
 }
 

--- a/service/updates/module.go
+++ b/service/updates/module.go
@@ -240,6 +240,14 @@ func (u *Updater) updateAndUpgrade(w *mgr.WorkerCtx, indexURLs []string, ignoreV
 	}
 	defer u.isUpdateRunning.UnSet()
 
+	// Resource updates can repair themselves without a restart. Re-apply the
+	// signed current index when startup verification found local corruption.
+	repairCorruptedResources := u.corruptedInstallation != nil && u.cfg.AutoApply && !u.cfg.NeedsRestart
+	if repairCorruptedResources {
+		ignoreVersion = true
+		log.Warningf("updates/%s: repairing corrupted resources", u.cfg.Name)
+	}
+
 	// Create a new downloader.
 	downloader := NewDownloader(u, indexURLs)
 
@@ -396,6 +404,10 @@ func (u *Updater) updateAndUpgrade(w *mgr.WorkerCtx, indexURLs []string, ignoreV
 	err = u.cleanupAfterUpgrade()
 	if err != nil {
 		log.Debugf("updates/%s: failed to clean up after upgrade: %s", u.cfg.Name, err)
+	}
+	if repairCorruptedResources {
+		u.corruptedInstallation = nil
+		u.states.Remove(corruptInstallationNotificationID)
 	}
 	u.EventResourcesUpdated.Submit(struct{}{})
 

--- a/service/updates/updates_test.go
+++ b/service/updates/updates_test.go
@@ -103,6 +103,56 @@ func TestPerformUpdate(t *testing.T) {
 	}
 }
 
+func TestPerformUpdateRepairsCorruptedResourcesAtSameVersion(t *testing.T) {
+	t.Parallel()
+
+	stub := &testInstance{}
+	installedDir := t.TempDir()
+	updateDir := t.TempDir()
+	purgeDir := t.TempDir()
+	published := time.Now()
+
+	if err := GenerateMockFolder(installedDir, "Test", "1.0.0", published); err != nil {
+		t.Fatal(err)
+	}
+	if err := GenerateMockFolder(updateDir, "Test", "1.0.0", published); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installedDir, "portmaster"), []byte("corrupted"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	updater, err := New(stub, "Test", Config{
+		Name:              "Test",
+		Directory:         installedDir,
+		DownloadDirectory: updateDir,
+		PurgeDirectory:    purgeDir,
+		IndexFile:         "index.json",
+		AutoDownload:      true,
+		AutoApply:         true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updater.corruptedInstallation == nil {
+		t.Fatal("expected corrupted installation to be detected")
+	}
+
+	m := mgr.New("updates repair test")
+	if err := m.Do("repair corrupted resources", func(w *mgr.WorkerCtx) error {
+		return updater.updateAndUpgrade(w, nil, false, false)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if updater.corruptedInstallation != nil {
+		t.Fatalf("expected corruption state to be cleared, got %v", updater.corruptedInstallation)
+	}
+	if err := updater.index.VerifyArtifacts(installedDir); err != nil {
+		t.Fatalf("expected installed artifacts to be repaired: %v", err)
+	}
+}
+
 // GenerateMockFolder generates mock index folder for testing.
 func GenerateMockFolder(dir, name, version string, published time.Time) error {
 	// Make sure dir exists


### PR DESCRIPTION
## Summary

- reapply the signed current index when an auto-applied, no-restart resource updater detects local artifact corruption
- clear the corruption state after the repaired resources are installed
- add a regression test for same-version artifact repair

## Root cause

The updater detects checksum mismatches while loading an installed index, but a normal update check still rejects the same signed index as already current. Intelligence resources therefore cannot repair a corrupted local artifact until the server publishes a newer index, and consumers such as filter-list ingestion keep retrying the damaged file.

This keeps the existing behavior for binary updates that require a restart and user confirmation. Only automatically applied resource updates are eligible for same-version self-repair.

Fixes #2188

## Validation

- `go test ./service/updates ./service/intel/filterlists -count=1`
- `go test -race ./service/updates -run 'TestPerformUpdate(RepairsCorruptedResourcesAtSameVersion)?$' -count=1`
- `go vet ./service/updates`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically repairs corrupted installed resources during startup when automatic updates are enabled.
  * Repairs can proceed even when installed and available versions are identical.
  * Clears outdated corruption notifications after successful repairs.
  * Removes stale filter list update warnings after a successful update check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->