### PR TITLE
fix(windows): preserve unrelated startup entries on uninstall

### DIFF
--- a/desktop/tauri/src-tauri/templates/nsis/install_hooks.nsh
+++ b/desktop/tauri/src-tauri/templates/nsis/install_hooks.nsh
@@ -179,7 +179,7 @@ var dataDir
 
   ; remove the registry entry for the autostart
   DetailPrint "Removing registry entry for autostart"
-  DeleteRegKey HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Run"
+  DeleteRegValue HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Run" "Portmaster"
 
   ; delete data files
   Delete  /REBOOTOK "$COMMONPROGRAMDATA\Portmaster\databases\history.db"


### PR DESCRIPTION
## Summary

- remove only the Portmaster startup value during NSIS uninstall
- preserve unrelated machine-wide startup entries

## Why

The installer creates a named Portmaster value in the shared HKLM CurrentVersion Run key. The uninstaller currently deletes the entire shared key, which removes startup entries belonging to Windows and other applications. This changes the cleanup operation to delete only the value created by Portmaster.

## Testing

- git diff --check
- verified that the install and uninstall hooks use the same registry path and value name
- full NSIS bundle not built locally because makensis is unavailable

Fixes #2140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Uninstalling the application now removes only its autostart registry entry, preserving other applications’ startup settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->