### PR TITLE
ci: upgrade golangci-lint to v2 and golangci-lint-action to v9

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,9 +42,9 @@ jobs:
         cache: false
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
+      uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
       with:
-        version: v1.64.6
+        version: v2.12.2
         only-new-issues: true
         args: -c ./.golangci.yml --timeout 15m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
-# Docs:
-# https://golangci-lint.run/usage/linters/
-
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
     - containedctx
     - contextcheck
@@ -27,7 +25,7 @@ linters:
     - noctx
     - nolintlint
     - nonamedreturns
-    - perfsprint # TODO(ppacher): we should re-enanble this one to avoid costly fmt.* calls in the hot-path
+    - perfsprint
     - revive
     - tagliatelle
     - testifylint
@@ -36,34 +34,45 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
-    - gci
-    - tenv # Deprecated
+    - wsl_v5
+  settings:
+    godox:
+      keywords:
+        - FIXME
+    gosec:
+      excludes:
+        - G204
+        - G304
+        - G505
+    revive:
+      enable-all-rules: true
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - golint
+        text: a blank import .*
+      - linters:
+          - staticcheck
+        text: 'ST1000: at least one file in a package should have a package comment.*'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/safing
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
-linters-settings:
-  revive:
-    # See https://github.com/mgechev/revive#available-rules for details.
-    enable-all-rules: true
-  goimports:
-    local-prefixes: github.com/safing
-  godox:
-    # report any comments starting with keywords, this is useful for TODO or FIXME comments that
-    # might be left in the code accidentally and should be resolved before merging
-    keywords:
-      - FIXME
-  gosec:
-    # To specify a set of rules to explicitly exclude.
-    # Available rules: https://github.com/securego/gosec#available-rules
-    excludes:
-      - G204 # Variables in commands.
-      - G304 # Variables in file paths.
-      - G505 # We need crypto/sha1 for non-security stuff. Using `nolint:` triggers another linter.
 
-issues:
-  exclude-use-default: false
-  exclude-rules:
-    - text: "a blank import .*"
-      linters:
-        - golint
-    - text: "ST1000: at least one file in a package should have a package comment.*"
-      linters:
-        - stylecheck


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated Go linting tools to newer versions.
  * Migrated lint configuration to the latest format.
  * Refined linting rules, exclusions, and formatting checks for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->