### PR TITLE
Improve nameserver UDP listener robustness and error handling

### DIFF
--- a/service/nameserver/module.go
+++ b/service/nameserver/module.go
@@ -155,6 +155,7 @@ func startListener(ip net.IP, port uint16, first bool) {
 		started := false
 		dnsServer.NotifyStartedFunc = func() {
 			started = true
+			deleteListenErrorNotification(first)
 		}
 
 		// Start listening.
@@ -169,7 +170,7 @@ func startListener(ip net.IP, port uint16, first bool) {
 			if !started {
 				// Failed to start listening. Probably some other application is already listening on the same port.
 				log.Warningf("nameserver: failed to start listening on %s: %s", dnsServer.Addr, err)
-				handleListenError(err, ip, port, first)
+				showListenErrorNotification(err, ip, port, first)
 			} else {
 				log.Warningf("nameserver: failed to serve on %s: %s", dnsServer.Addr, err)
 			}
@@ -178,7 +179,21 @@ func startListener(ip net.IP, port uint16, first bool) {
 	})
 }
 
-func handleListenError(err error, ip net.IP, port uint16, primaryListener bool) {
+func deleteListenErrorNotification(primaryListener bool) {
+	// Create suffix for secondary listener
+	var secondaryEventIDSuffix string
+	if !primaryListener {
+		secondaryEventIDSuffix = "-secondary"
+	}
+	// remove all possible notifications related to current listener (primary or secondary)
+	for _, eventID := range []string{eventIDConflictingService + secondaryEventIDSuffix, eventIDListenerFailed + secondaryEventIDSuffix} {
+		if n := notifications.Get(eventID); n != nil {
+			n.Delete()
+		}
+	}
+}
+
+func showListenErrorNotification(err error, ip net.IP, port uint16, primaryListener bool) {
 	var n *notifications.Notification
 
 	// Create suffix for secondary listener

--- a/service/nameserver/module.go
+++ b/service/nameserver/module.go
@@ -119,6 +119,7 @@ func startListener(ip net.IP, port uint16, first bool) {
 			),
 			Net:     "udp",
 			Handler: dns.HandlerFunc(handleRequestAsWorker),
+			UDPSize: dns.MaxMsgSize, // without this, one oversized datagram kills the listener on Windows
 		}
 
 		// Register stop function.
@@ -151,6 +152,11 @@ func startListener(ip net.IP, port uint16, first bool) {
 			module.states.Remove(eventIDListenerFailed)
 		}
 
+		started := false
+		dnsServer.NotifyStartedFunc = func() {
+			started = true
+		}
+
 		// Start listening.
 		log.Infof("nameserver: starting to listen on %s", dnsServer.Addr)
 		err := dnsServer.ListenAndServe()
@@ -159,8 +165,14 @@ func startListener(ip net.IP, port uint16, first bool) {
 			if module.mgr.IsDone() {
 				return nil
 			}
-			log.Warningf("nameserver: failed to listen on %s: %s", dnsServer.Addr, err)
-			handleListenError(err, ip, port, first)
+
+			if !started {
+				// Failed to start listening. Probably some other application is already listening on the same port.
+				log.Warningf("nameserver: failed to start listening on %s: %s", dnsServer.Addr, err)
+				handleListenError(err, ip, port, first)
+			} else {
+				log.Warningf("nameserver: failed to serve on %s: %s", dnsServer.Addr, err)
+			}
 		}
 		return err
 	})


### PR DESCRIPTION
Set `UDPSize` to `dns.MaxMsgSize` to ensure the listener can accommodate oversized datagrams without crashing on Windows. Introduced a mechanism to clear error notifications when the listener starts successfully, preventing persistent notifications after resolution. Enhanced error handling to differentiate between binding failures and runtime socket errors.

Fixes #2197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS server startup and listener error handling.
  * Added clearer distinction between startup failures and errors occurring after the server begins serving.
  * Increased the maximum supported UDP DNS message size.
  * Prevented outdated listener error notifications from remaining after successful startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->