### PR TITLE
Fix worker backoff invalidation and context mutation issues

### DIFF
--- a/service/mgr/worker.go
+++ b/service/mgr/worker.go
@@ -174,9 +174,9 @@ func (m *Manager) manageWorker(name string, fn func(w *WorkerCtx) error) {
 	w := &WorkerCtx{
 		name:     name,
 		workFunc: fn,
+		ctx:      m.ctx,
 		logger:   m.logger.With("worker", name),
 	}
-	w.ctx = m.ctx
 
 	m.workerStart(w)
 	defer m.workerDone(w)
@@ -320,8 +320,12 @@ func (m *Manager) do(name string, isStopWorker bool, fn func(w *WorkerCtx) error
 
 func (m *Manager) runWorker(w *WorkerCtx, fn func(w *WorkerCtx) error) (panicInfo string, err error) {
 	// Create worker context that is canceled when worker finished or dies.
-	w.ctx, w.cancelCtx = context.WithCancel(w.ctx)
-	defer w.Cancel()
+	runCtx := &WorkerCtx{
+		workerMgr: w.workerMgr,
+		logger:    w.logger,
+	}
+	runCtx.ctx, runCtx.cancelCtx = context.WithCancel(w.ctx)
+	defer runCtx.Cancel()
 
 	// Recover from panic.
 	defer func() {
@@ -358,7 +362,7 @@ func (m *Manager) runWorker(w *WorkerCtx, fn func(w *WorkerCtx) error) (panicInf
 		}
 	}()
 
-	err = fn(w)
+	err = fn(runCtx)
 	return //nolint
 }
 

--- a/service/mgr/worker.go
+++ b/service/mgr/worker.go
@@ -185,6 +185,7 @@ func (m *Manager) manageWorker(name string, fn func(w *WorkerCtx) error) {
 	failCnt := 0
 
 	for {
+		runStart := time.Now()
 		panicInfo, err := m.runWorker(w, fn)
 		switch {
 		case err == nil:
@@ -213,6 +214,12 @@ func (m *Manager) manageWorker(name string, fn func(w *WorkerCtx) error) {
 					)
 				}
 				return
+			}
+
+			// Reset backoff if the worker ran long enough to be considered healthy.
+			if time.Since(runStart) > time.Minute {
+				backoff = time.Second
+				failCnt = 0
 			}
 
 			// Count failure and increase backoff (up to limit),

--- a/service/mgr/worker_test.go
+++ b/service/mgr/worker_test.go
@@ -1,7 +1,9 @@
 package mgr
 
 import (
+	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -48,4 +50,65 @@ func testFunc3(ctx *WorkerCtx) error {
 	case <-ctx.Done():
 	}
 	return nil
+}
+
+func TestRunWorkerDoesNotMutateCallerContext(t *testing.T) { //nolint:paralleltest
+	m := New("test")
+	defer m.Cancel()
+
+	base := &WorkerCtx{
+		ctx:    m.Ctx(),
+		logger: m.logger.With("worker", "test"),
+	}
+	wantErr := errors.New("deliberate failure")
+
+	for _, tc := range []struct {
+		name string
+		fn   func(*WorkerCtx) error
+	}{
+		{"error only", func(_ *WorkerCtx) error { return wantErr }},
+		{"self-cancel then error", func(w *WorkerCtx) error { w.Cancel(); return wantErr }},
+	} {
+		_, err := m.runWorker(base, tc.fn)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("%s: expected %v, got %v", tc.name, wantErr, err)
+		}
+		if base.Ctx().Err() != nil {
+			t.Fatalf("%s: caller context must not be canceled after run, got: %v", tc.name, base.Ctx().Err())
+		}
+	}
+}
+
+// TestManagerGoRetryReceivesLiveContext is the regression test for the fix:
+// workers using select-on-Done must not silently exit on retry.
+func TestManagerGoRetryReceivesLiveContext(t *testing.T) { //nolint:paralleltest
+	m := New("test")
+	defer m.Cancel()
+
+	var runs atomic.Int32
+	done := make(chan struct{})
+
+	m.Go("retry-test", func(w *WorkerCtx) error {
+		switch runs.Add(1) {
+		case 1:
+			return errors.New("first-run failure")
+		case 2:
+			select {
+			case <-w.Done():
+				t.Error("retry context was already canceled")
+			default:
+			}
+			close(done)
+		}
+		return nil
+	})
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out after %d runs", runs.Load())
+	}
+	if runs.Load() != 2 {
+		t.Errorf("expected 2 runs, got %d", runs.Load())
+	}
 }


### PR DESCRIPTION
Reset the worker backoff and failure count after a healthy run to prevent stale backoff from causing unnecessary delays. Addressed context mutation by ensuring that the worker's context is not altered during retries, preventing silent exits on retry due to canceled contexts. Added regression tests to verify the integrity of the worker context and the retry mechanism.

Fixes safing/portmaster#2197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker retry behavior after extended failures.
  * Ensured worker retries receive an active context.
  * Prevented individual worker runs from canceling their parent operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->