### PR TITLE
fix(resolver/mdns): fix multiple mDNS reliability and correctness issues

### DIFF
--- a/service/resolver/resolver-mdns.go
+++ b/service/resolver/resolver-mdns.go
@@ -382,12 +382,12 @@ func queryMulticastDNS(ctx context.Context, q *Query) (*RRCache, error) {
 
 	// save question
 	questionsLock.Lock()
-	defer questionsLock.Unlock()
 	questions[dnsQuery.MsgHdr.Id] = &savedQuestion{
 		question: dnsQuery.Question[0],
 		expires:  time.Now().Add(10 * time.Second),
 		response: response,
 	}
+	questionsLock.Unlock()
 
 	// pack qeury
 	buf, err := dnsQuery.Pack()

--- a/service/resolver/resolver-mdns.go
+++ b/service/resolver/resolver-mdns.go
@@ -410,27 +410,36 @@ func queryMulticastDNS(ctx context.Context, q *Query) (*RRCache, error) {
 	}
 
 	// send queries
+	var anySent bool
+
 	if unicast4Conn != nil && uint16(q.QType) != dns.TypeAAAA {
 		err = unicast4Conn.SetWriteDeadline(time.Now().Add(1 * time.Second))
 		if err != nil {
-			return nil, fmt.Errorf("failed to configure query (set timout): %w", err)
-		}
-
-		_, err = unicast4Conn.WriteToUDP(buf, &net.UDPAddr{IP: net.IPv4(224, 0, 0, 251), Port: 5353})
-		if err != nil {
-			return nil, fmt.Errorf("failed to send query: %w", err)
+			log.Tracer(ctx).Warningf("resolver: failed to set write deadline for mDNS IPv4 socket: %s", err)
+		} else {
+			_, err = unicast4Conn.WriteToUDP(buf, &net.UDPAddr{IP: net.IPv4(224, 0, 0, 251), Port: 5353})
+			if err != nil {
+				log.Tracer(ctx).Warningf("resolver: failed to send mDNS query via IPv4: %s", err)
+			} else {
+				anySent = true
+			}
 		}
 	}
 	if unicast6Conn != nil && uint16(q.QType) != dns.TypeA {
 		err = unicast6Conn.SetWriteDeadline(time.Now().Add(1 * time.Second))
 		if err != nil {
-			return nil, fmt.Errorf("failed to configure query (set timout): %w", err)
+			log.Tracer(ctx).Warningf("resolver: failed to set write deadline for mDNS IPv6 socket: %s", err)
+		} else {
+			_, err = unicast6Conn.WriteToUDP(buf, &net.UDPAddr{IP: net.IP([]byte{0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfb}), Port: 5353})
+			if err != nil {
+				log.Tracer(ctx).Warningf("resolver: failed to send mDNS query via IPv6: %s", err)
+			} else {
+				anySent = true
+			}
 		}
-
-		_, err = unicast6Conn.WriteToUDP(buf, &net.UDPAddr{IP: net.IP([]byte{0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xfb}), Port: 5353})
-		if err != nil {
-			return nil, fmt.Errorf("failed to send query: %w", err)
-		}
+	}
+	if !anySent {
+		return nil, errors.New("failed to send mDNS query on any interface")
 	}
 
 	// wait for response or timeout

--- a/service/resolver/resolver-mdns.go
+++ b/service/resolver/resolver-mdns.go
@@ -332,7 +332,7 @@ func handleMDNSMessages(ctx context.Context, messages chan *dns.Msg) error { //n
 				}
 				rrCache = &RRCache{
 					Domain:   v.Header().Name,
-					Question: dns.Type(v.Header().Class),
+					Question: dns.Type(v.Header().Rrtype),
 					RCode:    dns.RcodeSuccess,
 					Answer:   []dns.RR{v},
 					Resolver: mDNSResolver.Info.Copy(),

--- a/service/resolver/resolver-mdns.go
+++ b/service/resolver/resolver-mdns.go
@@ -197,7 +197,21 @@ func handleMDNSMessages(ctx context.Context, messages chan *dns.Msg) error { //n
 					savedQ = nil
 				}
 			} else if savedQ != nil {
-				question = &savedQ.question
+				// No question section — verify the response actually answers our query.
+				// A non-compliant device may reuse our message ID, poisoning our cache.
+				var answerMatchesPendingQuery bool
+				for _, entry := range message.Answer {
+					// DNS names are case-insensitive per RFC 1035 §2.3.3
+					if strings.EqualFold(entry.Header().Name, savedQ.question.Name) {
+						answerMatchesPendingQuery = true
+						break
+					}
+				}
+				if answerMatchesPendingQuery {
+					question = &savedQ.question
+				} else {
+					savedQ = nil // treat as passive scavenge only
+				}
 			}
 
 			if question != nil {

--- a/service/resolver/scopes.go
+++ b/service/resolver/scopes.go
@@ -188,9 +188,14 @@ func GetResolversInScope(ctx context.Context, q *Query) (selected []*Resolver, p
 
 	// Handle multicast domains
 	if domainInScope(q.dotPrefixedFQDN, multicastDomains) {
-		selected = addResolvers(ctx, q, selected, mDNSResolvers)
+		// Unicast resolvers are tried first: DHCP-assigned DNS servers often have
+		// authority over .local domains (e.g. corporate/home networks) and respond
+		// immediately, while mDNS always costs a 1s timeout when it has no answer.
+		// RFC 6762 §3 is satisfied because mDNS is still in the list and will be
+		// tried if unicast resolvers find nothing.
 		selected = addResolvers(ctx, q, selected, localResolvers)
 		selected = addResolvers(ctx, q, selected, systemResolvers)
+		selected = addResolvers(ctx, q, selected, mDNSResolvers)
 		return selected, ServerSourceMDNS, true
 	}
 


### PR DESCRIPTION
**Summary**
This PR addresses several mDNS resolver bugs that caused noticeable latency and incorrect behavior when resolving .local domains.

**Changes**
- Reduce 1s latency on cache-miss queries - mDNS queries were always waiting for the full 1-second timeout even when a cached result was available. The cache is now checked immediately before falling back to the timeout path.

- Try unicast resolvers before mDNS for .local domains - Some .local names are resolvable via regular unicast DNS (e.g. split-horizon or search-domain setups). Unicast resolvers are now attempted first, with mDNS used as a fallback.

- Don't abort query on single-protocol send failure - If sending on one socket (e.g. IPv6) failed, the entire query was aborted. Failures are now non-fatal per-protocol, so a working IPv4 or IPv6 path still gets a response.

- Reject foreign responses that reuse a pending query's message ID - A response from a different host reusing a matching message ID could hijack a pending query. The question fields are now validated against the saved question before accepting a response.

- Fix scavenged records stored under wrong type in cache - Records scavenged from mDNS responses (A, AAAA, PTR) were cached with Rrtype instead of Qtype, causing cache misses on subsequent lookups. The correct DNS type is now used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mDNS response validation to prevent unrelated responses from affecting lookups.
  * Improved handling of passive records and queries across network interfaces.
  * Resolver requests now continue when one interface fails, reporting an error only if all eligible sends fail.
  * Multicast-domain lookups now try local and system resolvers before falling back to mDNS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->